### PR TITLE
[FIX] Open log file in append mode - logrotate couldn't truncate file

### DIFF
--- a/usb_monitor.c
+++ b/usb_monitor.c
@@ -415,7 +415,7 @@ int main(int argc, char *argv[])
     while ((retval = getopt(argc, argv, "o:c:dh")) != -1) {
         switch (retval) {
         case 'o':
-            usbmon_ctx->logfile = fopen(optarg, "w+");  
+            usbmon_ctx->logfile = fopen(optarg, "a+");
             break;
         case 'c':
             conf_file_name = optarg;


### PR DESCRIPTION
We need to open log file in append mode to let logrotate truncate the file.
