### PR TITLE
[FIX] Daemonize the process before we start to play with file descriptors

### DIFF
--- a/usb_monitor.c
+++ b/usb_monitor.c
@@ -436,6 +436,13 @@ int main(int argc, char *argv[])
         } 
     }
 
+    if (daemonize && daemon(1,1)) {
+        fprintf(stderr, "Failed to start usb-monitor as daemon\n");
+        fclose(usbmon_ctx->logfile);
+        libusb_exit(NULL);
+        exit(EXIT_FAILURE);
+    }
+
     if (usbmon_ctx->logfile == NULL) {
         fprintf(stderr, "Failed to create logfile\n");
         exit(EXIT_FAILURE);
@@ -465,13 +472,6 @@ int main(int argc, char *argv[])
 
     if (sigaction(SIGUSR1, &sig_handler, NULL)) {
         fprintf(stderr, "Could not intall signal handler\n");
-        exit(EXIT_FAILURE);
-    }
-
-    if (daemonize && daemon(1,1)) {
-        fprintf(stderr, "Failed to start usb-monitor as daemon\n");
-        fclose(usbmon_ctx->logfile);
-        libusb_exit(NULL);
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Behavior with -d option and without it was different. libusb fds were
removed from the event loop, because daemon does fork() operation
and child inherits copy of file descriptors (so parents file descriptors
were closed and removed from event loop). This fix just moves daemon()
call to the place before we open any file desciptor.
