### PR TITLE
Make GPIO handler more generic

### DIFF
--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -58,7 +58,7 @@ static ssize_t gpio_write_value(struct gpio_port *gport, uint8_t gpio_val)
         return bytes_written;
     }
 
-    USB_DEBUG_PRINT_SYSLOG(gport->ctx, LOG_INFO, "Will write %u to %s\n", gpio_val, file_path);
+    //USB_DEBUG_PRINT_SYSLOG(gport->ctx, LOG_INFO, "Will write %u to %s\n", gpio_val, file_path);
 
     if (gpio_val)
         bytes_written = write(fd, "1", 1);

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -287,7 +287,7 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
     char *path;
     const char *path_org, *gpio_path = NULL;
     int i, j;
-    int16_t gpio_num = -1; 
+    uint8_t gpio_num = 0; 
     uint8_t on_val = GPIO_DEFAULT_ON_VAL;
     uint8_t off_val = GPIO_DEFAULT_OFF_VAL;
     uint8_t unknown = 0;
@@ -302,7 +302,7 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
                 continue;
             } else if (!strcmp(key, "gpio_num") && json_object_is_type(val, json_type_int)) {
                 //GPIO number (used to create sysfs template)
-                gpio_num = (int16_t) json_object_get_int(val);
+                gpio_num = (uint8_t) json_object_get_int(val);
                 continue;
             } else if (!strcmp(key, "on_val") && json_object_is_type(val, json_type_int)) {
                 //Custom on value (some devices are GPIO-like)
@@ -325,8 +325,8 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
         if (unknown ||
             path_array == NULL ||
             !json_object_array_length(path_array) ||
-            (gpio_num == -1 && !gpio_path) ||
-            (gpio_num > 0 && gpio_path))
+            (!gpio_num && !gpio_path) ||
+            (gpio_num && gpio_path))
             return 1;
         
         for (j = 0; j < json_object_array_length(path_array); j++) {
@@ -337,14 +337,14 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
             if (!path)
                 return 1;
 
-            if (gpio_handler_add_port(ctx, path, (uint8_t) gpio_num, on_val,
-                                      off_val, gpio_path)) {
+            if (gpio_handler_add_port(ctx, path, gpio_num, on_val, off_val,
+                        gpio_path)) {
                 free(path);
                 return 1;
             }
 
             USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
-                                   "Read following GPIO from config %s (%d) on: %u off: %u\n",
+                                   "Read following GPIO from config %s (%u) on: %u off: %u\n",
                                    path_org, gpio_num, on_val, off_val);
             free(path);
         }

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -53,7 +53,7 @@ static ssize_t gpio_write_value(struct gpio_port *gport, uint8_t gpio_val)
     fd = open(file_path, O_WRONLY | FD_CLOEXEC);
 
     if (fd == -1) {
-        USB_DEBUG_PRINT_SYSLOG(gport->ctx, LOG_ERR, "Failed to open gpio file\n");
+        USB_DEBUG_PRINT_SYSLOG(gport->ctx, LOG_ERR, "Failed to open gpio file %s\n", file_path);
         //usb_helpers_start_timeout((struct usb_port*) gport, DEFAULT_TIMEOUT_SEC);
         return bytes_written;
     }
@@ -344,7 +344,7 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
             }
 
             USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
-                                   "Read following GPIO from config %s (%u) on: %u off: %u\n",
+                                   "Read following GPIO from config %s (%d) on: %u off: %u\n",
                                    path_org, gpio_num, on_val, off_val);
             free(path);
         }

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -181,8 +181,8 @@ static struct gpio_port* gpio_handler_create_port(struct usb_monitor_ctx *ctx,
     port->update = gpio_update_port;
     port->timeout = gpio_handle_timeout;
 
-    port->on_val = GPIO_DEFAULT_ON_VAL;
-    port->off_val = GPIO_DEFAULT_OFF_VAL;
+    port->on_val = on_val;
+    port->off_val = off_val;
     port->gpio_path = gpio_path;
 
     return port;

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -58,6 +58,8 @@ static ssize_t gpio_write_value(struct gpio_port *gport, uint8_t gpio_val)
         return bytes_written;
     }
 
+    USB_DEBUG_PRINT_SYSLOG(gport->ctx, LOG_INFO, "Will write %u to %s\n", gpio_val, file_path);
+
     if (gpio_val)
         bytes_written = write(fd, "1", 1);
     else

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -36,9 +36,7 @@ static void gpio_print_port(struct usb_port *port)
 
 static ssize_t gpio_write_value(struct gpio_port *gport, uint8_t gpio_val)
 {
-    //128 is large anough to store sysfs paths (/sys/class/gpio/gpioX/value) +
-    //glinet paths (and then some)
-    char file_path_arr[128];
+    char file_path_arr[GPIO_PATH_MAX_LEN];
     const char *file_path = file_path_arr;
     int32_t fd;
     ssize_t bytes_written = -1;
@@ -167,7 +165,7 @@ static struct gpio_port* gpio_handler_get_port(struct usb_monitor_ctx *ctx,
 }
 
 static struct gpio_port* gpio_handler_create_port(struct usb_monitor_ctx *ctx,
-        uint8_t gpio_num)
+        uint8_t gpio_num, uint8_t on_val, uint8_t off_val, const char *gpio_path)
 {
     struct gpio_port *port = calloc(sizeof(struct gpio_port), 1);
 
@@ -183,30 +181,55 @@ static struct gpio_port* gpio_handler_create_port(struct usb_monitor_ctx *ctx,
 
     port->on_val = GPIO_DEFAULT_ON_VAL;
     port->off_val = GPIO_DEFAULT_OFF_VAL;
+    port->gpio_path = gpio_path;
 
     return port;
 }
 
-static uint8_t gpio_handler_add_port(struct usb_monitor_ctx *ctx,
-        char *path, uint8_t gpio_num)
+static uint8_t gpio_handler_add_port_gpio_path(struct usb_monitor_ctx *ctx,
+        const char *dev_path_ptr, uint8_t dev_path_len, uint8_t on_val,
+        uint8_t off_val, const char *gpio_path)
 {
-    struct gpio_port *port;
+    struct gpio_port *port = NULL;
+    const char *gpio_path_cpy = NULL;
 
-    //Bus + port(s)
-    uint8_t dev_path[USB_PATH_MAX];
-    const char *dev_path_ptr = (const char *) dev_path;
-    uint8_t path_len = 0, do_configure = 0, retval = 0;
+    gpio_path_cpy = strdup(gpio_path);
 
-    if (usb_helpers_convert_char_to_path(path, dev_path, &path_len)) {
-        fprintf(stderr, "Path for GPIO device is too long\n");
+    if (!gpio_path_cpy) {
+        fprintf(stderr, "Failed to allocate memory for gpio path\n");
         return 1;
     }
+
+    //TODO: Add lookup for port when needed
+    port = gpio_handler_create_port(ctx, 0, on_val, off_val, gpio_path_cpy);
+
+    if (!port) {
+        fprintf(stderr, "Failed to allocate memory for gpio port\n");
+        return 1;
+    }
+
+    if(usb_helpers_configure_port((struct usb_port *) port,
+                ctx, dev_path_ptr, dev_path_len, 0, NULL)) {
+        fprintf(stderr, "Failed to configure gpio port\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static uint8_t gpio_handler_add_port_gpio_num(struct usb_monitor_ctx *ctx,
+        char *path, uint8_t gpio_num, const char *dev_path_ptr,
+        uint8_t dev_path_len)
+{
+    struct gpio_port *port;
+    uint8_t do_configure = 0, retval = 0;
 
     port = gpio_handler_get_port(ctx, gpio_num);
 
     //Port not found, create new
     if (!port) {
-        port = gpio_handler_create_port(ctx, gpio_num);
+        port = gpio_handler_create_port(ctx, gpio_num, GPIO_DEFAULT_ON_VAL,
+                GPIO_DEFAULT_OFF_VAL, NULL);
         do_configure = 1;
     }
 
@@ -218,10 +241,10 @@ static uint8_t gpio_handler_add_port(struct usb_monitor_ctx *ctx,
     //Update path
     if (do_configure)
         retval = usb_helpers_configure_port((struct usb_port *) port,
-                ctx, dev_path_ptr, path_len, gpio_num, NULL);
+                ctx, dev_path_ptr, dev_path_len, gpio_num, NULL);
     else
         retval = usb_helpers_port_add_path((struct usb_port *) port,
-                dev_path_ptr, path_len);
+                dev_path_ptr, dev_path_len);
 
     if (retval) {
         fprintf(stderr, "Failed to configure gpio port\n");
@@ -233,34 +256,77 @@ static uint8_t gpio_handler_add_port(struct usb_monitor_ctx *ctx,
     return retval;
 }
 
+static uint8_t gpio_handler_add_port(struct usb_monitor_ctx *ctx,
+        char *path, uint8_t gpio_num, uint8_t on_val, uint8_t off_val,
+        const char *gpio_path)
+{
+    //Bus + port(s)
+    uint8_t dev_path[USB_PATH_MAX];
+    const char *dev_path_ptr = (const char *) dev_path;
+    uint8_t dev_path_len = 0;
+
+    if (usb_helpers_convert_char_to_path(path, dev_path, &dev_path_len)) {
+        fprintf(stderr, "Path for GPIO device is too long\n");
+        return 1;
+    }
+
+    if (gpio_num) {
+        return gpio_handler_add_port_gpio_num(ctx, path, gpio_num, dev_path_ptr,
+                dev_path_len);
+    } else {
+        return gpio_handler_add_port_gpio_path(ctx, dev_path_ptr, dev_path_len,
+                on_val, off_val, gpio_path);
+    }
+}
+
 uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
                                 struct json_object *json)
 {
     int json_arr_len = json_object_array_length(json);
     struct json_object *json_port, *path_array = NULL, *json_path;
     char *path;
-    const char *path_org;
+    const char *path_org, *gpio_path = NULL;
     int i, j;
-    uint8_t gpio_num = -1, unknown = 0;
+    int16_t gpio_num = -1; 
+    uint8_t on_val = GPIO_DEFAULT_ON_VAL;
+    uint8_t off_val = GPIO_DEFAULT_OFF_VAL;
+    uint8_t unknown = 0;
 
     for (i = 0; i < json_arr_len; i++) {
         json_port = json_object_array_get_idx(json, i); 
 
         json_object_object_foreach(json_port, key, val) {
             if (!strcmp(key, "path") && json_object_is_type(val, json_type_array)) {
+                //USB path to match
                 path_array = val;
                 continue;
             } else if (!strcmp(key, "gpio_num") && json_object_is_type(val, json_type_int)) {
-                gpio_num = (uint8_t) json_object_get_int(val);
+                //GPIO number (used to create sysfs template)
+                gpio_num = (int16_t) json_object_get_int(val);
                 continue;
+            } else if (!strcmp(key, "on_val") && json_object_is_type(val, json_type_int)) {
+                //Custom on value (some devices are GPIO-like)
+                on_val = (uint8_t) json_object_get_int(val);
+                continue;
+            } else if (!strcmp(key, "off_val") && json_object_is_type(val, json_type_int)) {
+                //Custom off value
+                off_val = (uint8_t) json_object_get_int(val);
+                continue;
+            } else if (!strcmp(key, "gpio_path") && json_object_is_type(val, json_type_string)) {
+                //Custom path for GPIO like device (like modem on Glinet Mifi)
+                gpio_path = json_object_get_string(val);
+                break;
             } else {
                 unknown = 1;
                 break;
             }
         }
 
-        if (path_array == NULL || !json_object_array_length(path_array) ||
-                gpio_num == -1 || unknown)
+        if (unknown ||
+            path_array == NULL ||
+            !json_object_array_length(path_array) ||
+            (gpio_num == -1 && !gpio_path) ||
+            (gpio_num > 0 && gpio_path))
             return 1;
         
         for (j = 0; j < json_object_array_length(path_array); j++) {
@@ -271,14 +337,16 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
             if (!path)
                 return 1;
 
-            if (gpio_handler_add_port(ctx, path, gpio_num)) {
+            if (gpio_handler_add_port(ctx, path, (uint8_t) gpio_num, on_val,
+                                      off_val, gpio_path)) {
                 free(path);
                 return 1;
             }
 
-            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Read following GPIO from config %s (%u)\n", path_org, gpio_num);
+            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                                   "Read following GPIO from config %s (%u) on: %u off: %u\n",
+                                   path_org, gpio_num, on_val, off_val);
             free(path);
-
         }
     }
 

--- a/src/gpio_handler.h
+++ b/src/gpio_handler.h
@@ -20,10 +20,15 @@
 
 #include "usb_monitor.h"
 
+#define GPIO_DEFAULT_ON_VAL     1
+#define GPIO_DEFAULT_OFF_VAL    0
 #define GPIO_TIMEOUT_SLEEP_SEC 10
 
 struct gpio_port {
     USB_PORT_MANDATORY;
+    char *gpio_path;
+    uint8_t on_val;
+    uint8_t off_val;
 };
 
 struct json_object;

--- a/src/gpio_handler.h
+++ b/src/gpio_handler.h
@@ -20,13 +20,15 @@
 
 #include "usb_monitor.h"
 
-#define GPIO_DEFAULT_ON_VAL     1
-#define GPIO_DEFAULT_OFF_VAL    0
+#define GPIO_DEFAULT_ON_VAL    1
+#define GPIO_DEFAULT_OFF_VAL   0
 #define GPIO_TIMEOUT_SLEEP_SEC 10
+//64 is large anough to store maximum sysfs paths (/sys/class/gpio/gpioX/value)
+#define GPIO_PATH_MAX_LEN      64
 
 struct gpio_port {
     USB_PORT_MANDATORY;
-    char *gpio_path;
+    const char *gpio_path;
     uint8_t on_val;
     uint8_t off_val;
 };

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -416,6 +416,7 @@ static uint8_t usb_helpers_check_bad_id(struct usb_monitor_ctx *ctx, struct usb_
 
 void usb_helpers_reset_all_ports(struct usb_monitor_ctx *ctx, uint8_t forced)
 {
+#if 0
     struct usb_port *itr;
 
     USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "reset_all_ports\n");
@@ -430,6 +431,7 @@ void usb_helpers_reset_all_ports(struct usb_monitor_ctx *ctx, uint8_t forced)
                 usb_helpers_check_bad_id(ctx, itr))
             itr->update(itr, CMD_RESTART);
     }
+#endif
 }
 
 uint8_t usb_helpers_convert_char_to_path(char *path_str, uint8_t *path,

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -418,8 +418,6 @@ void usb_helpers_reset_all_ports(struct usb_monitor_ctx *ctx, uint8_t forced)
 {
     struct usb_port *itr;
 
-    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "reset_all_ports\n");
-
     LIST_FOREACH(itr, &(ctx->port_list), port_next) {
         //Only restart enabled ports which are not connected and are currently
         //not being reset

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -416,7 +416,6 @@ static uint8_t usb_helpers_check_bad_id(struct usb_monitor_ctx *ctx, struct usb_
 
 void usb_helpers_reset_all_ports(struct usb_monitor_ctx *ctx, uint8_t forced)
 {
-#if 0
     struct usb_port *itr;
 
     USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "reset_all_ports\n");
@@ -431,7 +430,6 @@ void usb_helpers_reset_all_ports(struct usb_monitor_ctx *ctx, uint8_t forced)
                 usb_helpers_check_bad_id(ctx, itr))
             itr->update(itr, CMD_RESTART);
     }
-#endif
 }
 
 uint8_t usb_helpers_convert_char_to_path(char *path_str, uint8_t *path,

--- a/src/usb_monitor_client.c
+++ b/src/usb_monitor_client.c
@@ -177,7 +177,6 @@ static uint8_t usb_monitor_client_update_ports(struct usb_monitor_ctx *ctx,
             if (!strcmp(key, "path"))
                 path = json_object_get_string(val);
             else if (!strcmp(key, "cmd"))
-                //We currently ignore cmd for now
                 cmd = (uint8_t) json_object_get_int(val);
         }
 


### PR DESCRIPTION
Several devices can be controlled in a similar way to gpio. I.e., write some value to a file to switch on/off the device. This commit adds support for devices like that by extending the gpio JSON object with support for the on_val, off_val and gpio_path keys. on_val sets the value for turning a device on, off_val sets value for turning off and gpio_path is the path to the file to write to.
