### PR TITLE
Implement first version of port probing

### DIFF
--- a/src/generic_handler.c
+++ b/src/generic_handler.c
@@ -28,7 +28,7 @@
 
 static void generic_print_port(struct usb_port *port)
 {
-    usb_helpers_print_port(port, "Generic");
+    usb_helpers_print_port(port, "Generic", NULL);
 }
 
 static void generic_update_cb(struct libusb_transfer *transfer)

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -31,7 +31,13 @@
 
 static void gpio_print_port(struct usb_port *port)
 {
-    usb_helpers_print_port(port, "GPIO");
+    struct gpio_port *g_port = (struct gpio_port *) port;
+
+    if (g_port->gpio_path) {
+        usb_helpers_print_port(port, "GPIO", g_port->gpio_path);
+    } else {
+        usb_helpers_print_port(port, "GPIO", NULL);
+    }
 }
 
 static ssize_t gpio_write_value(struct gpio_port *gport, uint8_t gpio_val)
@@ -70,10 +76,14 @@ static ssize_t gpio_write_value(struct gpio_port *gport, uint8_t gpio_val)
     return bytes_written;
 }
 
+//TODO: Wrap this one so that I can check for PROBE when requests from user
+//space arrives
 static int32_t gpio_update_port(struct usb_port *port, uint8_t cmd)
 {
     struct gpio_port *gport = (struct gpio_port*) port;
     uint8_t gpio_val = gport->off_val;
+
+    //TODO: If I am probing, start timer and return
 
     if (cmd == CMD_ENABLE) {
         if (gpio_write_value(gport, gport->on_val) <= 0)
@@ -136,12 +146,295 @@ static int32_t gpio_update_port(struct usb_port *port, uint8_t cmd)
     return 0;
 }
 
+//Find first port to probe. Returns 0 if no port could be found (we are done
+//probing)
+static uint8_t gpio_probe_enable_port(struct usb_monitor_ctx *ctx)
+{
+    struct usb_port *itr;
+    struct gpio_port *gpio_itr;
+
+    LIST_FOREACH(itr, &(ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO)
+            continue;
+
+        gpio_itr = (struct gpio_port*) itr;
+
+        if (gpio_itr->probe_state == PROBE_DOWN_DONE) {
+            if (gpio_update_port(itr, CMD_ENABLE)) {
+                USB_DEBUG_PRINT_SYSLOG(gpio_itr->ctx, LOG_INFO, "Failed to "
+                                       "enable port %s\n", gpio_itr->gpio_path);
+                usb_helpers_start_timeout(itr, GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+            } else {
+                USB_DEBUG_PRINT_SYSLOG(gpio_itr->ctx, LOG_INFO, "Probing port "
+                                       "%s\n", gpio_itr->gpio_path);
+                gpio_itr->probe_state = PROBE_UP;
+                usb_helpers_start_timeout(itr, GPIO_TIMEOUT_PROBE_ENABLE_SEC);
+            }
+
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static void gpio_on_probe_down_done(struct gpio_port *port)
+{
+    struct usb_port *itr;
+    struct gpio_port *gpio_itr;
+
+    //Check if any device has not successfully been shut down
+    LIST_FOREACH(itr, &(port->ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO)
+            continue;
+
+        gpio_itr = (struct gpio_port*) itr;
+
+        if (gpio_itr->vp.vid || gpio_itr->vp.pid) {
+            USB_DEBUG_PRINT_SYSLOG(gpio_itr->ctx, LOG_INFO, "Port %s still has "
+                                   "device connected\n", gpio_itr->gpio_path);
+            usb_helpers_start_timeout(itr, GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+            return;
+        }
+
+        gpio_itr->probe_state = PROBE_DOWN_DONE;
+    }
+
+    USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "All ports down, ready to "
+            "start probing\n");
+
+    //No need to check return value, we know there is always at least one port
+    //to enable
+    gpio_probe_enable_port(port->ctx);
+}
+
+//Called when setting a port as UP during probing times out. Could be because
+//there is no device, or because something is wrong with the device. Anyway, we
+//need to disable the port to prevent device from appearing after probing is
+//done for this port and before continuing. Remember that we assume ports are
+//accessed one by one while probing
+static void gpio_handle_probe_up_timeout(struct gpio_port *port)
+{
+    USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Probing port %s timed out\n",
+                           port->gpio_path);
+
+    //Set port as down
+    if (gpio_update_port((struct usb_port*) port, CMD_DISABLE)) {
+        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Port %s could not be "
+                               "disabled\n", port->gpio_path);
+    } else {
+        port->probe_state = PROBE_DOWN_2;
+        //When we run CMD_DISABLE, msg_mode is set to IDLE. We don't want that
+        port->msg_mode = PROBE;
+    }
+
+    usb_helpers_start_timeout((struct usb_port*) port,
+                              GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+}
+
+static void gpio_handler_restart_all_ports(struct usb_monitor_ctx *ctx)
+{
+    struct usb_port *itr;
+
+    LIST_FOREACH(itr, &(ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO) {
+            continue;
+        }
+
+        if (!itr->enabled) {
+            itr->msg_mode = IDLE;
+            gpio_update_port(itr, CMD_ENABLE);
+        } else {
+            //No need to reset msg_mode, it is done in update_port
+            gpio_update_port(itr, CMD_RESTART);
+        }
+    }
+}
+
+static void gpio_handler_handle_probe_done(struct usb_monitor_ctx *ctx)
+{
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Done with probing + writing conf\n");
+    //Restart all ports, so that we can handle devices
+    gpio_handler_restart_all_ports(ctx);
+}
+
+static struct json_object* gpio_create_mapping_json(struct usb_monitor_ctx *ctx)
+{
+    struct json_object *config_obj, *obj_add, *obj_arr, *obj_port, *obj_paths;
+    char path_buf[MAX_USB_PATH];
+    uint8_t path_buf_len, i;
+    struct usb_port *itr;
+    struct gpio_port *g_itr;
+
+    config_obj = json_object_new_object();
+    if (!config_obj) {
+        return NULL;
+    }
+
+    obj_add = json_object_new_string("GPIO");
+    if (!obj_add) {
+        json_object_put(config_obj);
+        return NULL;
+    }
+    json_object_object_add(config_obj, "name", obj_add);
+
+    obj_arr = json_object_new_array();
+    if (!obj_arr) {
+        json_object_put(config_obj);
+        return NULL;
+    }
+    json_object_object_add(config_obj, "ports", obj_arr);
+
+    LIST_FOREACH(itr, &(ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO) {
+            continue;
+        }
+
+        g_itr = (struct gpio_port*) itr;
+
+        obj_port = json_object_new_object();
+        if (!obj_port) {
+            json_object_put(config_obj);
+            return NULL;
+        }
+        json_object_array_add(obj_arr, obj_port);
+
+        obj_add = json_object_new_string(g_itr->gpio_path);
+        if (!obj_add) {
+            json_object_put(config_obj);
+            return NULL;
+        }
+        json_object_object_add(obj_port, "gpio_path", obj_add);
+
+        if (g_itr->on_val != GPIO_DEFAULT_ON_VAL) {
+            obj_add = json_object_new_int(g_itr->on_val);
+            if (!obj_add) {
+                json_object_put(config_obj);
+                return NULL;
+            }
+            json_object_object_add(obj_port, "on_val", obj_add);
+        }
+
+        if (g_itr->off_val != GPIO_DEFAULT_OFF_VAL) {
+            obj_add = json_object_new_int(g_itr->off_val);
+            if (!obj_add) {
+                json_object_put(config_obj);
+                return NULL;
+            }
+            json_object_object_add(obj_port, "off_val", obj_add);
+        }
+
+        obj_paths = json_object_new_array();
+        if (!obj_paths) {
+            json_object_put(config_obj);
+            return NULL;
+        }
+        json_object_object_add(obj_port, "path", obj_paths);
+
+        for (i = 0; i < MAX_NUM_PATHS; i++) {
+            if (!itr->path[i]) {
+                break;
+            }
+
+            usb_helpers_convert_path_char(itr, path_buf, &path_buf_len, i);
+
+            obj_add = json_object_new_string_len(path_buf, path_buf_len);
+            if (!obj_add) {
+                json_object_put(config_obj);
+                return NULL;
+            }
+            json_object_array_add(obj_paths, obj_add);
+        }
+    }
+
+    return config_obj;
+}
+
+static void gpio_write_config(struct gpio_port *port)
+{
+    struct json_object *config_obj;
+    const char *config_json_str;
+    FILE *mapping_file;
+    size_t retval;
+
+    USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Will write port mapping to "
+                           "file\n");
+
+    if (!(config_obj = gpio_create_mapping_json(port->ctx))) {
+        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Creating mapping JSON "
+                                                    "failed\n");
+        port->probe_state = PROBE_WRITE_FILE;
+        usb_helpers_start_timeout((struct usb_port*) port,
+                GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+        return;
+    }
+
+    config_json_str = json_object_to_json_string_ext(config_obj,
+                                                     JSON_C_TO_STRING_PLAIN);
+
+    USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Will write: %s\n",
+                           config_json_str);
+
+    mapping_file = fopen(port->port_mapping_path, "w");
+    if (!mapping_file) {
+        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Opening mapping file "
+                                                    "failed\n");
+        port->probe_state = PROBE_WRITE_FILE;
+        usb_helpers_start_timeout((struct usb_port*) port,
+                GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+        return;
+    }
+
+    retval = fwrite(config_json_str, 1, strlen(config_json_str), mapping_file);
+
+    if (retval != strlen(config_json_str)) {
+        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Writing mapping failed\n");
+        port->probe_state = PROBE_WRITE_FILE;
+        usb_helpers_start_timeout((struct usb_port*) port,
+                GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+    } else {
+        gpio_handler_handle_probe_done(port->ctx);
+    }
+
+    fclose(mapping_file);
+    json_object_put(config_obj);
+}
+
+static void gpio_handle_probe_down_2(struct gpio_port *port)
+{
+    USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Probing port %s disabled after"
+                           " PROBE_UP timeout\n", port->gpio_path);
+    port->probe_state = PROBE_DONE;
+
+    if (!gpio_probe_enable_port(port->ctx)) {
+        gpio_write_config(port);
+    }
+}
+
+static void gpio_on_probe_timeout(struct gpio_port *port)
+{
+    if (port->probe_state == PROBE_DOWN ||
+        port->probe_state == PROBE_DOWN_DONE) {
+        port->probe_state = PROBE_DOWN_DONE;
+        gpio_on_probe_down_done(port);
+    } else if (port->probe_state == PROBE_UP) {
+        gpio_handle_probe_up_timeout(port);
+    } else if (port->probe_state == PROBE_DOWN_2) {
+        gpio_handle_probe_down_2(port); 
+    } else if (port->probe_state == PROBE_WRITE_FILE) {
+        gpio_write_config(port);
+    }
+}
+
 static void gpio_handle_timeout(struct usb_port *port)
 {
-    if (port->msg_mode == PING)
+    if (port->msg_mode == PING) {
         usb_helpers_send_ping(port);
-    else
+    } else if (port->msg_mode == PROBE) {
+        gpio_on_probe_timeout((struct gpio_port*) port);
+    } else {
         gpio_update_port(port, CMD_RESTART);
+    }
 }
 
 //For GPIO, what is unique is the gpio number. A gpio number might be mapped to
@@ -167,7 +460,7 @@ static struct gpio_port* gpio_handler_get_port(struct usb_monitor_ctx *ctx,
 }
 
 static struct gpio_port* gpio_handler_create_port(struct usb_monitor_ctx *ctx,
-        uint8_t gpio_num, uint8_t on_val, uint8_t off_val, const char *gpio_path)
+        uint16_t gpio_num, uint8_t on_val, uint8_t off_val, const char *gpio_path)
 {
     struct gpio_port *port = calloc(sizeof(struct gpio_port), 1);
 
@@ -184,6 +477,7 @@ static struct gpio_port* gpio_handler_create_port(struct usb_monitor_ctx *ctx,
     port->on_val = on_val;
     port->off_val = off_val;
     port->gpio_path = gpio_path;
+    port->gpio_num = gpio_num;
 
     return port;
 }
@@ -220,7 +514,7 @@ static uint8_t gpio_handler_add_port_gpio_path(struct usb_monitor_ctx *ctx,
 }
 
 static uint8_t gpio_handler_add_port_gpio_num(struct usb_monitor_ctx *ctx,
-        char *path, uint8_t gpio_num, const char *dev_path_ptr,
+        uint16_t gpio_num, const char *dev_path_ptr,
         uint8_t dev_path_len)
 {
     struct gpio_port *port;
@@ -273,7 +567,7 @@ static uint8_t gpio_handler_add_port(struct usb_monitor_ctx *ctx,
     }
 
     if (gpio_num) {
-        return gpio_handler_add_port_gpio_num(ctx, path, gpio_num, dev_path_ptr,
+        return gpio_handler_add_port_gpio_num(ctx, gpio_num, dev_path_ptr,
                 dev_path_len);
     } else {
         return gpio_handler_add_port_gpio_path(ctx, dev_path_ptr, dev_path_len,
@@ -289,7 +583,7 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
     char *path;
     const char *path_org, *gpio_path = NULL;
     int i, j;
-    uint8_t gpio_num = 0; 
+    uint16_t gpio_num = 0; 
     uint8_t on_val = GPIO_DEFAULT_ON_VAL;
     uint8_t off_val = GPIO_DEFAULT_OFF_VAL;
     uint8_t unknown = 0;
@@ -317,7 +611,7 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
             } else if (!strcmp(key, "gpio_path") && json_object_is_type(val, json_type_string)) {
                 //Custom path for GPIO like device (like modem on Glinet Mifi)
                 gpio_path = json_object_get_string(val);
-                break;
+                continue;
             } else {
                 unknown = 1;
                 break;
@@ -328,16 +622,18 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
             path_array == NULL ||
             !json_object_array_length(path_array) ||
             (!gpio_num && !gpio_path) ||
-            (gpio_num && gpio_path))
+            (gpio_num && gpio_path)) {
             return 1;
+        }
         
         for (j = 0; j < json_object_array_length(path_array); j++) {
             json_path = json_object_array_get_idx(path_array, j);
             path_org = json_object_get_string(json_path);
             path = strdup(path_org);
 
-            if (!path)
+            if (!path) {
                 return 1;
+            }
 
             if (gpio_handler_add_port(ctx, path, gpio_num, on_val, off_val,
                         gpio_path)) {
@@ -345,12 +641,215 @@ uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx,
                 return 1;
             }
 
-            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
-                                   "Read following GPIO from config %s (%u) on: %u off: %u\n",
-                                   path_org, gpio_num, on_val, off_val);
+            if (gpio_num) {
+                USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                                       "Read following GPIO from config %s (%u)"
+                                       " on: %u off: %u\n", path_org, gpio_num,
+                                       on_val, off_val);
+            } else {
+                 USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                                       "Read following GPIO from config %s (%s)"
+                                       " on: %u off: %u\n", path_org, gpio_path,
+                                       on_val, off_val);
+            }
             free(path);
         }
     }
 
     return 0;
+}
+
+int32_t gpio_handler_start_probe(struct usb_monitor_ctx *ctx,
+                                 const char *port_mapping_path)
+{
+    struct usb_port *itr;
+    struct gpio_port *port = NULL;
+
+    LIST_FOREACH(itr, &(ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO)
+            continue;
+
+        port = (struct gpio_port*) itr;
+
+        if (gpio_update_port(itr, CMD_DISABLE)) {
+            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_ERR,
+                                   "Failed to start probe for pin %s\n",
+                                   port->gpio_path);
+            return -1; 
+        }
+
+        USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                               "Started probe for pin %s\n", port->gpio_path);
+        port->probe_state = PROBE_DOWN;
+        port->msg_mode = PROBE;
+
+        //Yet another argument for refactoring code and creating a GPIO handler,
+        //that will then contain all the ports. Storing the path in every object
+        //is ... not nice
+        port->port_mapping_path = port_mapping_path;
+
+        //Timeout is started when we add a device (in order to run USB ping).
+        //Stop timeout for all ports here. It is maybe not very elegant, but I
+        //found it easier than adding some probe/non-probe check to the generic
+        //add helper
+        if (usb_monitor_lists_is_timeout_active(itr)) {
+            usb_monitor_lists_del_timeout(itr);
+        }
+    }
+
+    //Does not matter which port we start the timer for
+    //TODO: Consider restructuring usb monitor to have a handler for every port
+    //type (and not just port objects for != Ykush). Right now, for example this
+    //timer is used as a global timer for GPIO, but the timer is actually tied
+    //to only one port. The code works because access to ports is serialized
+    //while probing, but the structure is a bit confusing
+    usb_helpers_start_timeout((struct usb_port*) port,
+                              GPIO_TIMEOUT_PROBE_DISABLE_SEC);
+
+    return 0;
+}
+
+//port_match is the the port that we matched on in the
+//usb_device_added-callback, while port_probe is the port that was probed. We
+//will swap path + device information between match and probe, as the mapping is
+//wrong and it is port_probe the controls the device path stored in port_match
+static void gpio_handler_swap_port_info(struct usb_port *port_match,
+                                        struct usb_port *port_probe)
+{
+    char *path_tmp[MAX_NUM_PATHS] = {0};
+    uint8_t path_len_tmp[MAX_NUM_PATHS] = {0};
+    uint8_t i;
+    struct usb_monitor_ctx *ctx = port_match->ctx;
+
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Will swap path mapping "
+                           "(before)\n");
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Port (match):\n");
+    gpio_print_port(port_match);
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Port (probe):\n");
+    gpio_print_port(port_probe);
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "\n");
+
+    //Move from the port we matched on to temporary, and NULL original
+    for (i = 0; i < MAX_NUM_PATHS; i++) {
+        if (!port_match->path[i]) {
+            break;
+        }
+
+        path_tmp[i] = port_match->path[i];
+        path_len_tmp[i] = port_match->path_len[i];
+        port_match->path[i] = NULL;
+    }
+
+    //Move from port we probed and to the port we matched on
+    for (i = 0; i < MAX_NUM_PATHS; i++) {
+        if (!port_probe->path[i]) {
+            break;
+        }
+
+        port_match->path[i] = port_probe->path[i];
+        port_match->path_len[i] = port_probe->path_len[i];
+        port_probe->path[i] = NULL;
+    }
+
+    //Move the mapping from the port we matched on and to the port we probe
+    for (i = 0; i < MAX_NUM_PATHS; i++) {
+        if (!path_tmp[i]) {
+            break;
+        }
+
+        port_probe->path[i] = path_tmp[i];
+        port_probe->path_len[i] = path_len_tmp[i];
+    }
+
+    //Also need to copy/reset the information about the current device
+    port_probe->vp.vid = port_match->vp.vid;
+    port_probe->vp.pid = port_match->vp.pid;
+    port_probe->status = port_match->status;
+    port_probe->dev = port_match->dev;
+
+    port_match->vp.vid = port_match->vp.pid = port_match->status = 0;
+    port_match->dev = NULL;
+
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Will swap path mapping "
+                           "(after)\n");
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Port (match):\n");
+    gpio_print_port(port_match);
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Port (probe):\n");
+    gpio_print_port(port_probe);
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "\n");
+}
+
+void gpio_handler_handle_probe_connect(struct usb_port *port)
+{
+    struct usb_port *itr;
+    struct gpio_port *g_port;
+
+    //This guard is needed in case we time out in the same iteration of the
+    //event loop as the connect message of the device. We can only connect one
+    //and one device (enable one and one port), so if a port is set to
+    //PROBE_DOWN_2 then we should not accept any new devices. That the device
+    //might get added to the wrong port is not so important, port is being set
+    //as down anyway
+    LIST_FOREACH(itr, &(port->ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO) {
+            continue;
+        }
+
+        g_port = (struct gpio_port*) port;
+
+        if (g_port->probe_state == PROBE_DOWN_2) {
+            USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Port is being set as "
+                                   "down after timeout. Do not accept new "
+                                   "devices\n");
+            return;
+        }
+    }
+
+    g_port = (struct gpio_port*) port;
+
+    //If the device connected maps to the port we are probing, mapping is
+    //correct
+    if (g_port->probe_state == PROBE_UP) {
+        USB_DEBUG_PRINT_SYSLOG(g_port->ctx, LOG_INFO, "Path mapping correct for"
+                               " %s\n", g_port->gpio_path);
+        usb_monitor_lists_del_timeout(port);
+        g_port->probe_state = PROBE_DONE;
+        
+        //Probe next port
+        if (!gpio_probe_enable_port(port->ctx)) {
+            gpio_write_config(g_port);
+        }
+
+        return;
+    }
+
+    //Path mismatch, need to find correct port
+    g_port = NULL;
+
+    LIST_FOREACH(itr, &(port->ctx->port_list), port_next) {
+        if (itr->port_type != PORT_TYPE_GPIO)
+            continue;
+
+        g_port = (struct gpio_port*) itr;
+
+        if (g_port->probe_state == PROBE_UP) {
+            break;
+        }
+    }
+
+    //This can happen if a probed device for example crashes or is in some other
+    //way restarted while we are probin. State is set to PROBE_DONE, so we will
+    //not match any port
+    if (!g_port) {
+        return;
+    }
+   
+    gpio_handler_swap_port_info(port, itr);
+
+    usb_monitor_lists_del_timeout(itr);
+    g_port->probe_state = PROBE_DONE;
+
+    if (!gpio_probe_enable_port(port->ctx)) {
+        gpio_write_config(g_port);
+    }
 }

--- a/src/gpio_handler.h
+++ b/src/gpio_handler.h
@@ -20,21 +20,39 @@
 
 #include "usb_monitor.h"
 
-#define GPIO_DEFAULT_ON_VAL    1
-#define GPIO_DEFAULT_OFF_VAL   0
-#define GPIO_TIMEOUT_SLEEP_SEC 10
+#define GPIO_DEFAULT_ON_VAL             1
+#define GPIO_DEFAULT_OFF_VAL            0
+#define GPIO_TIMEOUT_SLEEP_SEC          10
+#define GPIO_TIMEOUT_PROBE_DISABLE_SEC  5
+#define GPIO_TIMEOUT_PROBE_ENABLE_SEC   60
 //64 is large anough to store maximum sysfs paths (/sys/class/gpio/gpioX/value)
 #define GPIO_PATH_MAX_LEN      64
+
+enum {
+    PROBE_IDLE = 0,
+    PROBE_DOWN,
+    PROBE_DOWN_DONE,
+    PROBE_UP,
+    PROBE_DOWN_2,
+    PROBE_DONE,
+    PROBE_WRITE_FILE
+};
 
 struct gpio_port {
     USB_PORT_MANDATORY;
     const char *gpio_path;
+    const char *port_mapping_path;
+    uint16_t gpio_num;
     uint8_t on_val;
     uint8_t off_val;
+    uint8_t probe_state;
 };
 
 struct json_object;
 
 uint8_t gpio_handler_parse_json(struct usb_monitor_ctx *ctx, struct json_object *json);
 
+int32_t gpio_handler_start_probe(struct usb_monitor_ctx *ctx, const char *probe_mapping_path);
+
+void gpio_handler_handle_probe_connect(struct usb_port *port);
 #endif

--- a/src/usb_helpers.h
+++ b/src/usb_helpers.h
@@ -34,7 +34,8 @@ uint8_t usb_helpers_port_add_path(struct usb_port *port, const char *path,
                                   uint8_t path_len);
 
 //Generic output function for a usb port
-void usb_helpers_print_port(struct usb_port *port, const char *type);
+void usb_helpers_print_port(struct usb_port *port, const char *type,
+                            const char *prefix);
 
 //Get the per-port power switching value
 int8_t usb_helpers_get_power_switch(struct usb_monitor_ctx *ctx,

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -450,6 +450,20 @@ static uint8_t usb_monitor_configure(struct usb_monitor_ctx *ctx, uint8_t sock)
     return 0;
 }
 
+static int32_t usb_monitor_start_probe(const char *probe_mapping_path)
+{
+    struct usb_port *itr;
+
+    LIST_FOREACH(itr, &(usbmon_ctx->port_list), port_next) {
+        //If/when we adde more handlers, probing should be made a callback
+        if (itr->port_type == PORT_TYPE_GPIO) {
+            return gpio_handler_start_probe(usbmon_ctx, probe_mapping_path);
+        }
+    }
+
+    return 0;
+}
+
 static void usb_monitor_print_usage()
 {
     fprintf(stdout, "usb monitor command line arguments:\n");
@@ -458,6 +472,9 @@ static void usb_monitor_print_usage()
     fprintf(stdout, "\t-g : group id of usb monitor socket (optional)\n");
     fprintf(stdout, "\t-d : run as daemon\n");
     fprintf(stdout, "\t-s : write to syslog\n");
+    fprintf(stdout, "\t-p : generate pin/port mapping dynamically. This value "
+            "is set to the path of new mapping file (optional, only GPIO for "
+            "now, default is empty)\n");
     fprintf(stdout, "\t-h : this output\n");
 }
 
@@ -466,7 +483,7 @@ int main(int argc, char *argv[])
 {
     int retval = 0;
     uint8_t daemonize = 0;
-    char *conf_file_name = NULL;
+    char *conf_file_name = NULL, *probe_mapping_path = NULL;
     struct sigaction sig_handler;
     int32_t pid_fd, i;
 
@@ -490,7 +507,7 @@ int main(int argc, char *argv[])
 
     usbmon_ctx->logfile = stderr;
 
-    while ((retval = getopt(argc, argv, "o:c:g:dhs")) != -1) {
+    while ((retval = getopt(argc, argv, "o:c:g:dhsp:")) != -1) {
         switch (retval) {
         case 'o':
             usbmon_ctx->logfile = fopen(optarg, "a+");
@@ -506,6 +523,9 @@ int main(int argc, char *argv[])
             break;
         case 'g':
             usbmon_ctx->group_id = atoi(optarg);
+            break;
+        case 'p':
+            probe_mapping_path = optarg;
             break;
         case 'h':
         default:
@@ -570,6 +590,12 @@ int main(int argc, char *argv[])
             USB_DEBUG_PRINT_SYSLOG(usbmon_ctx, LOG_INFO, "0x%.4x:0x%.4x\n",
                                    usbmon_ctx->bad_device_ids[i].vid,
                                    usbmon_ctx->bad_device_ids[i].pid);
+        }
+    }
+
+    if (probe_mapping_path) {
+        if (usb_monitor_start_probe(probe_mapping_path)) {
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/src/usb_monitor.h
+++ b/src/usb_monitor.h
@@ -90,7 +90,8 @@ enum {
 enum port_msg {
     IDLE = 0,
     PING,
-    RESET
+    RESET,
+    PROBE
 };
 
 enum port_status {

--- a/src/usb_monitor_client.c
+++ b/src/usb_monitor_client.c
@@ -199,6 +199,12 @@ static uint8_t usb_monitor_client_update_ports(struct usb_monitor_ctx *ctx,
         if (port_ptr == NULL)
             continue;
 
+        if (port_ptr->port_type == PORT_TYPE_GPIO &&
+            port_ptr->msg_mode == PROBE) {
+            failure = 1;
+            break;
+        }
+
         if ((cmd == CMD_ENABLE && port_ptr->enabled) ||
             (cmd == CMD_DISABLE && !port_ptr->enabled))
             continue;

--- a/src/usb_monitor_lists.c
+++ b/src/usb_monitor_lists.c
@@ -67,8 +67,9 @@ struct usb_port *usb_monitor_lists_find_port_path(struct usb_monitor_ctx *ctx,
                 break;
 
             if ((itr->path_len[i] == path_len) &&
-                (!memcmp(itr->path[i], path, path_len)))
+                (!memcmp(itr->path[i], path, path_len))) {
                 return itr;
+            }
         }
     }
 
@@ -85,6 +86,11 @@ void usb_monitor_lists_del_timeout(struct usb_port *port)
     LIST_REMOVE(port, timeout_next);
     port->timeout_next.le_next = NULL;
     port->timeout_next.le_prev = NULL;
+}
+
+uint8_t usb_monitor_lists_is_timeout_active(struct usb_port *port)
+{
+    return port->timeout_next.le_next || port->timeout_next.le_prev;
 }
 
 /* HUB list functions  */

--- a/src/usb_monitor_lists.h
+++ b/src/usb_monitor_lists.h
@@ -39,5 +39,6 @@ struct usb_port *usb_monitor_lists_find_port_path(struct usb_monitor_ctx *ctx,
 //Add or delete port from timeout list
 void usb_monitor_lists_add_timeout(struct usb_monitor_ctx *ctx, struct usb_port *port);
 void usb_monitor_lists_del_timeout(struct usb_port *port);
+uint8_t usb_monitor_lists_is_timeout_active(struct usb_port *port);
 
 #endif

--- a/src/ykush_handler.c
+++ b/src/ykush_handler.c
@@ -33,7 +33,7 @@ static int32_t ykush_update_port(struct usb_port *port, uint8_t cmd);
 /* TODO: Parts of this function is generic, split in two */
 static void ykush_print_port(struct usb_port *port)
 {
-    usb_helpers_print_port(port, "YKUSH");
+    usb_helpers_print_port(port, "YKUSH", NULL);
 }
 
 static void ykush_enable_cb(struct libusb_transfer *transfer)


### PR DESCRIPTION
A hardware vendor we are working with switched which USB port is
controlled by which GPIO, and there is no easy way to check the
port/gpio mapping of a device. In order to work around this issue, we
need to probe each GPIO and detect which device gets connected. The
current approach is as follows (on devices where we do probing):

* First, we disable all GPIO that controls USB ports.
* We wait five seconds for the ports to be switched off and any devices
to disconnect. Five seconds seems to be more than enough, based on our
testing with the affected device.
* After the timeout has expired, we turn on the first port we find in
our list. We give the device in the port 60 seconds to connect. 60
seconds is enough (and then some) for all our modems to boot + connect,
at least it has been during testing.
* When device is connected, we check if the path matches what is stored
for the port we enabled. If not, we swap the USB device path between the
port that matched and the port that was enabled.
* If we match, or timeout expires, we mark that probing is done and
enable the next port.
* In addition, for timeout we disable the enabled port. The reason for
doing this is to prevent devices from connecting after we are done
probing. We then wait five seconds before enabling the port again,
blocking any connection attempt.
* When we have probed all devices, we write the new configuration to
file and resume normal operartion.
* Next time usb-monitor is started, it will read the configuration from
file.

Limitations:
* Probing works best when a device in inserted in all ports that will be
probed.
* We only support swapping. This means that we can't discover new paths,
only incorrect mappings between pins and paths.
* Assumes that usb-monitor has full control over usb/pins.

I have tested this feature by first making sure that it work, and then
trying to trigger the different error cases + ensuring that all
different global timers are triggered. Feature seems to work fine, I
have not been able to break probing and we correctly fix the mapping on
"broken" devices.