### PR TITLE
Use clock_gettime

### DIFF
--- a/src/backend_event_loop.c
+++ b/src/backend_event_loop.c
@@ -19,7 +19,7 @@
 #include <sys/epoll.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/time.h>
+#include <time.h>
 
 //Remove
 #include <stdio.h>
@@ -133,11 +133,11 @@ static void backend_event_loop_run_timers(struct backend_event_loop *del)
 {
     struct backend_timeout_handle *timeout = del->timeout_list.lh_first;
     struct backend_timeout_handle *cur_timeout;
-    struct timeval tv;
+    struct timespec tp;
     uint64_t cur_time;
 
-    gettimeofday(&tv, NULL);
-    cur_time = (tv.tv_sec * 1e3) + (tv.tv_usec / 1e3);
+    clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+    cur_time = (tp.tv_sec * 1e3) + (tp.tv_nsec / 1e6);
 
     while (timeout != NULL) {
         if (timeout->timeout_clock <= cur_time) {
@@ -169,15 +169,15 @@ void backend_event_loop_run(struct backend_event_loop *del)
     struct epoll_event events[MAX_EPOLL_EVENTS];
     int nfds, i, sleep_time;
 
-    struct timeval tv;
+    struct timespec tp;
     uint64_t cur_time;
     struct backend_timeout_handle *timeout;
 
     while(1){
         usb_handle = NULL;
         timeout = del->timeout_list.lh_first;
-        gettimeofday(&tv, NULL);
-        cur_time = (tv.tv_sec * 1e3) + (tv.tv_usec / 1e3);
+        clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+        cur_time = (tp.tv_sec * 1e3) + (tp.tv_nsec / 1e6);
        
         if (timeout != NULL) {
             if (cur_time > timeout->timeout_clock)

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include "usb_helpers.h"
 #include "usb_monitor.h"
@@ -216,10 +217,11 @@ uint8_t usb_helpers_get_num_ports(struct usb_monitor_ctx *ctx,
 
 void usb_helpers_start_timeout(struct usb_port *port, uint8_t timeout_sec)
 {
-    struct timeval tv;
+    struct timespec tp;
 
-    gettimeofday(&tv, NULL);
-    port->timeout_expire = ((tv.tv_sec + timeout_sec) * 1e6) + tv.tv_usec;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+
+    port->timeout_expire = ((tp.tv_sec + timeout_sec) * 1e6) + (tp.tv_nsec/1e3);
     usb_monitor_lists_add_timeout(port->ctx, port);
 }
 

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/epoll.h>
+#include <time.h>
 
 #include <json-c/json.h>
 #include <libusb-1.0/libusb.h>
@@ -243,12 +244,11 @@ static void usb_monitor_signal_handler(int signum)
 
 static void usb_monitor_start_event_loop(struct usb_monitor_ctx *ctx)
 {
-    struct timeval tv;
+    struct timespec tp;
     uint64_t cur_time;
 
-    gettimeofday(&tv, NULL);
-
-    cur_time = (tv.tv_sec * 1e3) + (tv.tv_usec / 1e3);
+    clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+    cur_time = (tp.tv_sec * 1e3) + (tp.tv_nsec / 1e6);
 
     //These timeout pointers will live for as long as the application.
     //Therefore, there is no need to save them anywhere

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -184,12 +184,18 @@ void usb_monitor_usb_event_cb(void *ptr, int32_t fd, uint32_t events)
 void usb_monitor_check_devices_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
+	USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                "devices_cb\n");
+
     usb_helpers_check_devices(ctx);
 }
 
 void usb_monitor_check_reset_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
+	USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                "reset_cb\n");
+
     usb_helpers_reset_all_ports(ctx, 0);
 }
 
@@ -199,6 +205,9 @@ void usb_monitor_itr_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
     struct timeval tv = {0 ,0};
+
+	USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                "itr_cb\n");
 
     //First, check for any of libusb's timers. We are incontrol of timer, so no
     //need for this function to block

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <sys/epoll.h>
 #include <unistd.h>
+#include <time.h>
 
 #include "usb_logging.h"
 #include "usb_monitor.h"
@@ -144,11 +145,11 @@ int usb_monitor_cb(libusb_context *ctx, libusb_device *device,
 static void usb_monitor_check_timeouts(struct usb_monitor_ctx *ctx)
 {
     struct usb_port *timeout_itr = NULL, *old_timeout = NULL;
-    struct timeval tv;
+    struct timespec tp;
     uint64_t cur_time;
 
-    gettimeofday(&tv, NULL);
-    cur_time = (tv.tv_sec * 1e6) + tv.tv_usec;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+    cur_time = (tp.tv_sec * 1e6) + (tp.tv_nsec/1e3);
 
     timeout_itr = ctx->timeout_list.lh_first;
 

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -184,18 +184,12 @@ void usb_monitor_usb_event_cb(void *ptr, int32_t fd, uint32_t events)
 void usb_monitor_check_devices_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
-	USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
-                "devices_cb\n");
-
     usb_helpers_check_devices(ctx);
 }
 
 void usb_monitor_check_reset_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
-	USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
-                "reset_cb\n");
-
     usb_helpers_reset_all_ports(ctx, 0);
 }
 
@@ -205,9 +199,6 @@ void usb_monitor_itr_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
     struct timeval tv = {0 ,0};
-
-	USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
-                "itr_cb\n");
 
     //First, check for any of libusb's timers. We are incontrol of timer, so no
     //need for this function to block


### PR DESCRIPTION
Replace gettimeofday with clock_gettime(CLOCK_MONOTONIC_RAW). We only use the time values for timestamps, so no need for wall clock. Switchting to MONTONIC_RAW removes unpleasant surprises when for example ntp kicks in.