### PR TITLE
gpio: Write port map to shadow file

### DIFF
--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -594,6 +594,11 @@ int main(int argc, char *argv[])
     }
 
     if (probe_mapping_path) {
+        if (strlen(probe_mapping_path) > GPIO_PROBE_PATH_LEN) {
+            USB_DEBUG_PRINT_SYSLOG(usbmon_ctx, LOG_ERR, "Gpio probe path too long\n");
+            exit(EXIT_FAILURE);
+        }
+
         if (usb_monitor_start_probe(probe_mapping_path)) {
             exit(EXIT_FAILURE);
         }

--- a/src/usb_monitor.h
+++ b/src/usb_monitor.h
@@ -34,6 +34,8 @@
 #define NUM_CONNECTIONS 1
 #define MAX_HTTP_CLIENTS 5
 
+#define GPIO_PROBE_PATH_LEN 127 //buffer size is 128 + 4 (.tmp)
+
 struct usb_port;
 struct backend_epoll_handle;
 struct backend_event_loop;


### PR DESCRIPTION
We should write the port map to a shadow file, and then do link when
file is written. This ensures that we don't end up with broken
configurations. One cases where we have seen broken configs, is when
router is rebooted after file is created and before write is flushed to
disk.

Link is atomic, so it is either successful or not. This means that when
link is successful, then we have a known good config.