### PR TITLE
Supper per-port power-cycling on Lanner devices

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(usb_monitor
                generic_handler.c
                ykush_handler.c
                gpio_handler.c
+               lanner_handler.c
                backend_event_loop.c
                socket_utility.c
                http_parser.c

--- a/src/backend_event_loop.c
+++ b/src/backend_event_loop.c
@@ -220,7 +220,8 @@ void backend_event_loop_run(struct backend_event_loop *del)
         if (usb_handle)
             usb_handle->cb(usb_handle->data, usb_handle->fd, 0);
 
-        if (del->itr_cb != NULL)
+        if (del->itr_cb != NULL) {
             del->itr_cb(del->itr_data);
+        }
     }
 }

--- a/src/backend_event_loop.h
+++ b/src/backend_event_loop.h
@@ -18,6 +18,7 @@
 #define BACKEND_EVENT_LOOP_H
 
 #include <sys/queue.h>
+#include <stdbool.h>
 
 #define MAX_EPOLL_EVENTS 10
 
@@ -49,6 +50,7 @@ struct backend_timeout_handle{
     LIST_ENTRY(backend_timeout_handle) timeout_next;
     uint32_t intvl;
     void *data;
+    bool auto_free;
 };
 
 struct backend_event_loop{
@@ -68,11 +70,16 @@ struct backend_event_loop* backend_event_loop_create();
 int32_t backend_event_loop_update(struct backend_event_loop *del, uint32_t events,
         int32_t op, int32_t fd, void *ptr);
 
+//For when we need to manually need to handle our timeouts
+void backend_insert_timeout(struct backend_event_loop *del,
+                            struct backend_timeout_handle *handle);
+void backend_delete_timeout(struct backend_timeout_handle *timeout);
+
 //Add a timeout which is controlled by main loop
 struct backend_timeout_handle* backend_event_loop_add_timeout(
         struct backend_event_loop *del, uint64_t timeout_clock,
         backend_timeout_cb timeout_cb, void *ptr,
-        uint32_t intvl);
+        uint32_t intvl, bool free_after_use);
 
 //Fill handle with ptr, fd, and cb. Used by create_epoll_handle and can be used
 //by applications that use a different allocater for handle

--- a/src/gpio_handler.c
+++ b/src/gpio_handler.c
@@ -479,7 +479,6 @@ static struct gpio_port* gpio_handler_get_port(struct usb_monitor_ctx *ctx,
     }
 
     return port;
-
 }
 
 static struct gpio_port* gpio_handler_create_port(struct usb_monitor_ctx *ctx,

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -47,6 +47,7 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
 
     if (cmd == CMD_RESTART) {
         l_port->restart_cmd = CMD_DISABLE;
+        l_port->msg_mode = RESET;
     }
 
     //"Register" this port with the shared structure
@@ -111,6 +112,13 @@ static uint8_t lanner_handler_add_port(struct usb_monitor_ctx *ctx,
     }
 
     return 0;
+}
+
+static void lanner_handle_flush_mcu(struct lanner_shared *l_shared)
+{
+    uint8_t tmp_buf[255];
+
+    while (read(l_shared->mcu_fd, tmp_buf, sizeof(tmp_buf)) > 0) {}
 }
 
 static uint8_t lanner_handler_open_mcu(struct lanner_shared *l_shared)
@@ -200,6 +208,8 @@ static uint8_t lanner_handler_open_mcu(struct lanner_shared *l_shared)
     }
 
     l_shared->mcu_fd = fd;
+
+    lanner_handle_flush_mcu(l_shared);
 
     return 0;
 }

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -25,7 +25,6 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
 static void lanner_handle_timeout(struct usb_port *port)
 {
     if (port->msg_mode == PING) {
-        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Sending ping\n");
         usb_helpers_send_ping(port);
     } else {
         USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Timeout\n");

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -31,8 +31,6 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
     struct lanner_port *l_port = (struct lanner_port*) port;
     struct lanner_shared *l_shared = l_port->shared_info;
 
-    return 503;
-
     //Order of operations here is:
     //* Return an error if shared is not IDLE/PENDING
     //* Set cmd of port to whatever is stored

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -37,7 +37,7 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
     //* Update bitmask of shared
     if (l_shared->mcu_state != LANNER_MCU_IDLE &&
         l_shared->mcu_state != LANNER_MCU_PENDING) {
-        //TODO: Update to return 503 instead
+        USB_DEBUG_PRINT_SYSLOG(l_port->ctx, LOG_INFO, "Lanner MCU busy\n");
         return 503;
     }
 
@@ -268,7 +268,7 @@ static void lanner_handler_write_cmd_buf(struct lanner_shared *l_shared)
         } else {
             //I don't know what to do here? Can it happen? Can we recover? Just
             //add EPOLLIN and hope for the best? exit?
-            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_ERR, "Failed to write to MCU: "
+            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_ERR, "Failed to write to Lanner MCU: "
                                    "%s (%d)\n", strerror(errno), errno);
         }
 
@@ -333,7 +333,7 @@ static void lanner_handler_ok_reply(struct lanner_shared *l_shared)
         }
     }
 
-    USB_DEBUG_PRINT_SYSLOG(l_shared->ctx, LOG_INFO, "MCU mask after OK: %u\n",
+    USB_DEBUG_PRINT_SYSLOG(l_shared->ctx, LOG_INFO, "Lanner MCU mask after OK: %u\n",
                            l_shared->pending_ports_mask);
 
     if (!l_shared->pending_ports_mask) {
@@ -363,7 +363,7 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
     //port will be enabled again by our watchdog.
     if (numbytes + l_shared->input_progress > (sizeof(l_shared->buf_input) - 1)) {
         USB_DEBUG_PRINT_SYSLOG(l_shared->ctx, LOG_ERR,
-                               "Oversized reply from MCU\n");
+                               "Oversized reply from Lanner MCU\n");
         exit(EXIT_FAILURE);
     }
 
@@ -445,7 +445,7 @@ void lanner_handler_start_mcu_update(struct usb_monitor_ctx *ctx)
 
     snprintf(l_shared->cmd_buf, sizeof(l_shared->cmd_buf),
              "SET DIGITAL_OUT %u\n", mcu_bitmask);
-    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "MCU cmd %s", l_shared->cmd_buf);
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Lanner MCU cmd %s", l_shared->cmd_buf);
 
     memset(l_shared->buf_input, 0, sizeof(l_shared->buf_input));
     l_shared->input_progress = 0;

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -372,7 +372,7 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
         return;
     }
 
-    if (strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
+    if (!strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
                  strlen(LANNER_HANDLER_OK_REPLY))) {
         lanner_handler_ok_reply(l_shared);
     } else {

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -44,6 +44,10 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
     //based on the different cur_cmd values
     l_port->cur_cmd = cmd;
 
+    if (cmd == CMD_RESTART) {
+        l_port->restart_cmd = CMD_DISABLE;
+    }
+
     //"Register" this port with the shared structure
     l_shared->pending_ports_mask |= l_port->bitmask;
 
@@ -112,7 +116,8 @@ static uint8_t lanner_handler_add_port(struct usb_monitor_ctx *ctx,
 
 static uint8_t lanner_handler_open_mcu(struct lanner_shared *l_shared)
 {
-    int fd = open(l_shared->mcu_path, O_RDWR | O_NONBLOCK | O_CLOEXEC), retval;
+    int fd = open(l_shared->mcu_path, O_RDWR | O_NOCTTY | O_NONBLOCK |
+                  O_CLOEXEC), retval;
     struct termios mcu_attr;
 
     if (fd == -1) {
@@ -300,8 +305,9 @@ static void lanner_handler_ok_reply(struct lanner_shared *l_shared)
 static void lanner_handler_handle_input(struct lanner_shared *l_shared)
 {
     uint8_t input_buf_tmp[256] = {0};
-    ssize_t numbytes = read(l_shared->mcu_fd, input_buf_tmp,
-                            (sizeof(input_buf_tmp) - 1));
+    /*ssize_t numbytes = read(l_shared->mcu_fd, input_buf_tmp,
+                            (sizeof(input_buf_tmp) - 1));*/
+    ssize_t numbytes = read(l_shared->mcu_fd, input_buf_tmp, 1);
     uint8_t i;
     bool found_newline = false;
 

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -139,6 +139,30 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
         return 1;
     }
 
+    if (!(mcu_path = strdup(mcu_path_org))) {
+        return 1;
+    }
+
+    l_shared = calloc(sizeof(struct lanner_shared), 1);
+
+    if (!l_shared) {
+        free(mcu_path);
+        return 1;
+    }
+
+    l_shared->mcu_path = mcu_path;
+
+    if (lanner_handler_open_mcu(l_shared)) {
+        free(mcu_path);
+        free(l_shared);
+        return 1;
+    }
+
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Lanner shared info. Path: %s "
+                           "FD: %d\n", l_shared->mcu_path,
+                           l_shared->mcu_fd);
+
+
     for (i = 0; i < json_arr_len; i++) {
         json_port = json_object_array_get_idx(json, i); 
 
@@ -158,29 +182,6 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
             return 1;
         }
        
-        if (!(mcu_path = strdup(mcu_path_org))) {
-            return 1;
-        }
-
-        l_shared = calloc(sizeof(struct lanner_shared), 1);
-
-        if (!l_shared) {
-            free(mcu_path);
-            return 1;
-        }
-
-        l_shared->mcu_path = mcu_path;
-
-        if (lanner_handler_open_mcu(l_shared)) {
-            free(mcu_path);
-            free(l_shared);
-            return 1;
-        }
-
-        USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Lanner shared info. Path: %s "
-                               "FD: %d\n", l_shared->mcu_path,
-                               l_shared->mcu_fd);
-
         for (j = 0; j < json_object_array_length(path_array); j++) {
             json_path = json_object_array_get_idx(path_array, j);
             path_org = json_object_get_string(json_path);

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -123,6 +123,19 @@ static uint8_t lanner_handler_open_mcu(struct lanner_shared *l_shared)
     return 0;
 }
 
+static void lanner_handler_cleanup_shared(struct lanner_shared *l_shared)
+{
+    if (l_shared->mcu_fd) {
+        close(l_shared->mcu_fd);
+    }
+
+    if (l_shared->mcu_path) {
+        free(l_shared->mcu_path);
+    }
+
+    free(l_shared);
+}
+
 uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
                                   struct json_object *json,
                                   const char *mcu_path_org)
@@ -153,15 +166,13 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
     l_shared->mcu_path = mcu_path;
 
     if (lanner_handler_open_mcu(l_shared)) {
-        free(mcu_path);
-        free(l_shared);
+        lanner_handler_cleanup_shared(l_shared);
         return 1;
     }
 
     USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO, "Lanner shared info. Path: %s "
                            "FD: %d\n", l_shared->mcu_path,
                            l_shared->mcu_fd);
-
 
     for (i = 0; i < json_arr_len; i++) {
         json_port = json_object_array_get_idx(json, i); 
@@ -188,17 +199,13 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
             path = strdup(path_org);
 
             if (!path) {
-                close(l_shared->mcu_fd);
-                free(mcu_path);
-                free(l_shared);
+                lanner_handler_cleanup_shared(l_shared);
                 return 1;
             }
 
             if (lanner_handler_add_port(ctx, path, bit)) {
-                close(l_shared->mcu_fd);
                 free(path);
-                free(mcu_path);
-                free(l_shared);
+                lanner_handler_cleanup_shared(l_shared);
                 return 1;
             }
 

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -38,7 +38,7 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
     if (l_shared->mcu_state != LANNER_MCU_IDLE &&
         l_shared->mcu_state != LANNER_MCU_PENDING) {
         //TODO: Update to return 503 instead
-        return 1;
+        return 503;
     }
 
     //We keep the current command in the port. The bitmask will be generated
@@ -383,7 +383,7 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
         return;
     }
 
-    if (!strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
+    if (strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
                  strlen(LANNER_HANDLER_OK_REPLY))) {
         lanner_handler_ok_reply(l_shared);
     } else {

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -1,0 +1,63 @@
+#include <json-c/json.h>
+#include <string.h>
+
+#include "usb_monitor.h"
+#include "usb_logging.h"
+#include "lanner_handler.h"
+
+uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx, struct json_object *json)
+{
+    int json_arr_len = json_object_array_length(json);
+    struct json_object *json_port, *path_array = NULL, *json_path;
+    char *path;
+    const char *path_org;
+    int i, j;
+    uint8_t bit = UINT8_MAX, unknown_option = 0;
+
+    for (i = 0; i < json_arr_len; i++) {
+        json_port = json_object_array_get_idx(json, i); 
+
+        json_object_object_foreach(json_port, key, val) {
+            if (!strcmp(key, "path") && json_object_is_type(val, json_type_array)) {
+                path_array = val;
+                continue;
+            } else if (!strcmp(key, "bit") && json_object_is_type(val, json_type_int)) {
+                bit = (uint8_t) json_object_get_int(val);
+                continue;
+            } else {
+                unknown_option = 1;
+                break;
+            }
+        }
+
+        if (unknown_option ||
+            bit == UINT8_MAX ||
+            !path_array ||
+            !json_object_array_length(path_array)) {
+            return 1;
+        }
+        
+        for (j = 0; j < json_object_array_length(path_array); j++) {
+            json_path = json_object_array_get_idx(path_array, j);
+            path_org = json_object_get_string(json_path);
+            path = strdup(path_org);
+
+            if (!path) {
+                return 1;
+            }
+
+            /*if (gpio_handler_add_port(ctx, path, gpio_num, on_val, off_val,
+                        gpio_path)) {
+                free(path);
+                return 1;
+            }*/
+
+            USB_DEBUG_PRINT_SYSLOG(ctx, LOG_INFO,
+                                   "Read following info from config %s (%u)"
+                                   " (Lanner)\n", path_org, bit);
+            free(path);
+        }
+    }
+
+    return 0;
+}

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -294,7 +294,6 @@ static void lanner_handler_ok_reply(struct lanner_shared *l_shared)
 
     if (!l_shared->pending_ports_mask) {
         l_shared->mcu_state = LANNER_MCU_IDLE;
-        l_shared->pending_ports_mask = 0;
     }
 }
 

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -378,8 +378,8 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
     } else {
         USB_DEBUG_PRINT_SYSLOG(l_shared->ctx, LOG_INFO, "Read %zd bytes: %s\n",
                                numbytes, input_buf_tmp);
-
-        //START A TIME OR SOMETHING HERE
+        l_shared->mcu_state = LANNER_MCU_WRITING;
+        lanner_handler_start_private_timer(l_shared, LANNER_HANDLER_RESTART_MS);
     }
 }
 

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -24,7 +24,12 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
 
 static void lanner_handle_timeout(struct usb_port *port)
 {
-    USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Timeout\n");
+    if (port->msg_mode == PING) {
+        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Sending ping\n");
+        usb_helpers_send_ping(port);
+    } else {
+        USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO, "Timeout\n");
+    }
 }
 
 static uint8_t lanner_handler_add_port(struct usb_monitor_ctx *ctx,

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -31,6 +31,8 @@ static int32_t lanner_update_port(struct usb_port *port, uint8_t cmd)
     struct lanner_port *l_port = (struct lanner_port*) port;
     struct lanner_shared *l_shared = l_port->shared_info;
 
+    return 503;
+
     //Order of operations here is:
     //* Return an error if shared is not IDLE/PENDING
     //* Set cmd of port to whatever is stored

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -124,15 +124,20 @@ static uint8_t lanner_handler_open_mcu(struct lanner_shared *l_shared)
 }
 
 uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
-                                  struct json_object *json)
+                                  struct json_object *json,
+                                  const char *mcu_path_org)
 {
     int json_arr_len = json_object_array_length(json);
     struct json_object *json_port, *path_array = NULL, *json_path;
     char *path, *mcu_path;
-    const char *path_org, *mcu_path_org = NULL;
+    const char *path_org;
     int i, j;
     uint8_t bit = UINT8_MAX, unknown_option = 0;
     struct lanner_shared *l_shared;
+
+    if (!mcu_path_org) {
+        return 1;
+    }
 
     for (i = 0; i < json_arr_len; i++) {
         json_port = json_object_array_get_idx(json, i); 
@@ -142,15 +147,13 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
                 path_array = val;
             } else if (!strcmp(key, "bit") && json_object_is_type(val, json_type_int)) {
                 bit = (uint8_t) json_object_get_int(val);
-            } else if (!strcmp(key, "mcu_path") && json_object_is_type(val, json_type_string)) {
-                mcu_path_org = json_object_get_string(val);
             } else {
                 unknown_option = 1;
                 break;
             }
         }
 
-        if (unknown_option || bit == UINT8_MAX || !path_array || !mcu_path_org
+        if (unknown_option || bit == UINT8_MAX || !path_array
             || !json_object_array_length(path_array)) {
             return 1;
         }

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -246,7 +246,14 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
     //This is not very clean, lanner state should ideally be completely
     //isolated. However, I prefer this approach to iterating through ports and
     //finding the first Lanner port (for example)
-    ctx->mcu_state = l_shared;
+    ctx->mcu_info = l_shared;
 
     return 0;
+}
+
+void lanner_handler_start_mcu_update(struct usb_monitor_ctx *ctx)
+{
+    struct lanner_shared *l_shared = ctx->mcu_info;
+
+    l_shared->mcu_state = LANNER_MCU_WRITING;
 }

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -99,7 +99,6 @@ static uint8_t lanner_handler_add_port(struct usb_monitor_ctx *ctx,
     //This is the bitmask used to enable/disable the port. The reason bit is
     //not zero-indexed in config, is to be consistent with Lanner tools/doc
     port->bitmask = 1 << (bit - 1);
-    port->cur_state = LANNER_STATE_ON;
 
     //If we get into the situation where multiple paths are controlled by the
     //same bit, we need to implement a lookup here (similar to gpio and

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -315,6 +315,7 @@ static void lanner_handler_ok_reply(struct lanner_shared *l_shared)
         if (cmd_to_check == CMD_ENABLE) {
             l_port->enabled = 1;
             l_port->pwr_state = 1;
+            l_port->msg_mode = IDLE;
 
             //Always unset bit in ENABLE. It is either a command itself or the
             //last part of restart (restart is done)

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -173,7 +173,9 @@ static void lanner_handler_write_cmd_buf(struct lanner_shared *l_shared)
     struct usb_monitor_ctx *ctx = l_shared->ctx;
     //uint8_t bytes_to_write = l_shared->cmd_buf_strlen - l_shared->cmd_buf_progress;
     uint8_t bytes_to_write = 1;
-    ssize_t numbytes = write(l_shared->mcu_fd, l_shared->cmd_buf, bytes_to_write);
+    ssize_t numbytes = write(l_shared->mcu_fd,
+                             l_shared->cmd_buf + l_shared->cmd_buf_progress,
+                             bytes_to_write);
     uint32_t monitor_events;
 
     if (numbytes == -1) {

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -329,6 +329,7 @@ static void lanner_handler_ok_reply(struct lanner_shared *l_shared)
     if (!l_shared->pending_ports_mask) {
         l_shared->mcu_state = LANNER_MCU_IDLE;
     } else {
+        l_shared->mcu_state = LANNER_MCU_WRITING;
         lanner_handler_start_private_timer(l_shared, LANNER_HANDLER_RESTART_MS);
     }
 }

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -372,7 +372,7 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
         return;
     }
 
-    if (!strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
+    if (strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
                  strlen(LANNER_HANDLER_OK_REPLY))) {
         lanner_handler_ok_reply(l_shared);
     } else {

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -133,7 +133,7 @@ static uint8_t lanner_handler_open_mcu(struct lanner_shared *l_shared)
     }
 
     //Baud rate is 57600 according to documentation
-    retval = tcgetattr(fd, &mcu_attr); 
+    retval = tcgetattr(fd, &mcu_attr);
 
     if (retval) {
         fprintf(stderr, "Fetching terminal attributes failed: %s (%d)\n",
@@ -515,7 +515,7 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
                            l_shared->mcu_fd);
 
     for (i = 0; i < json_arr_len; i++) {
-        json_port = json_object_array_get_idx(json, i); 
+        json_port = json_object_array_get_idx(json, i);
 
         json_object_object_foreach(json_port, key, val) {
             if (!strcmp(key, "path") && json_object_is_type(val, json_type_array)) {
@@ -533,7 +533,7 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
             lanner_handler_cleanup_shared(l_shared);
             return 1;
         }
-       
+
         for (j = 0; j < json_object_array_length(path_array); j++) {
             json_path = json_object_array_get_idx(path_array, j);
             path_org = json_object_get_string(json_path);

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -38,7 +38,8 @@ static void lanner_handle_timeout(struct usb_port *port)
 }
 
 static uint8_t lanner_handler_add_port(struct usb_monitor_ctx *ctx,
-                                       char *dev_path, uint8_t bit)
+                                       char *dev_path, uint8_t bit,
+                                       struct lanner_shared *l_shared)
 {
     uint8_t dev_path_array[USB_PATH_MAX];
     const char *dev_path_ptr = (const char *) dev_path_array;
@@ -63,6 +64,7 @@ static uint8_t lanner_handler_add_port(struct usb_monitor_ctx *ctx,
     port->update = lanner_update_port;
     port->timeout = lanner_handle_timeout;
 
+    port->shared_info = l_shared;
     //This is the bitmask used to enable/disable the port. The reason bit is
     //not zero-indexed in config, is to be consistent with Lanner tools/doc
     port->bitmask = 1 << (bit - 1);
@@ -203,7 +205,7 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
                 return 1;
             }
 
-            if (lanner_handler_add_port(ctx, path, bit)) {
+            if (lanner_handler_add_port(ctx, path, bit, l_shared)) {
                 free(path);
                 lanner_handler_cleanup_shared(l_shared);
                 return 1;

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -211,8 +211,8 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
     ssize_t numbytes = read(l_shared->mcu_fd, input_buf_tmp,
                             sizeof(input_buf_tmp));
 
-    USB_DEBUG_PRINT_SYSLOG(l_shared->ctx, LOG_INFO, "Read %zd bytes\n",
-                           numbytes);
+    USB_DEBUG_PRINT_SYSLOG(l_shared->ctx, LOG_INFO, "Read %zd bytes: %s\n",
+                           numbytes, input_buf_tmp);
 }
 
 static void lanner_handler_event_cb(void *ptr, int32_t fd, uint32_t events)

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -383,7 +383,7 @@ static void lanner_handler_handle_input(struct lanner_shared *l_shared)
         return;
     }
 
-    if (strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
+    if (!strncmp(LANNER_HANDLER_OK_REPLY, l_shared->buf_input,
                  strlen(LANNER_HANDLER_OK_REPLY))) {
         lanner_handler_ok_reply(l_shared);
     } else {

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -236,7 +236,8 @@ static void lanner_handler_start_private_timer(struct lanner_shared *l_shared,
 
     l_shared->mcu_timeout_handle->timeout_clock = cur_time + timeout_ms;
 
-    backend_insert_timeout(NULL, l_shared->mcu_timeout_handle);
+    backend_insert_timeout(l_shared->ctx->event_loop,
+                           l_shared->mcu_timeout_handle);
 }
 
 static void lanner_handler_write_cmd_buf(struct lanner_shared *l_shared)
@@ -486,6 +487,7 @@ uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
         lanner_handler_cleanup_shared(l_shared);
         return 1;
     }
+
     if (!(l_shared->mcu_timeout_handle = backend_event_loop_add_timeout(ctx->event_loop,
                                                                         0,
                                                                         lanner_handle_private_timeout,

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -171,7 +171,8 @@ static void lanner_handler_cleanup_shared(struct lanner_shared *l_shared)
 static void lanner_handler_write_cmd_buf(struct lanner_shared *l_shared)
 {
     struct usb_monitor_ctx *ctx = l_shared->ctx;
-    uint8_t bytes_to_write = l_shared->cmd_buf_strlen - l_shared->cmd_buf_progress;
+    //uint8_t bytes_to_write = l_shared->cmd_buf_strlen - l_shared->cmd_buf_progress;
+    uint8_t bytes_to_write = 1;
     ssize_t numbytes = write(l_shared->mcu_fd, l_shared->cmd_buf, bytes_to_write);
     uint32_t monitor_events;
 

--- a/src/lanner_handler.c
+++ b/src/lanner_handler.c
@@ -294,6 +294,7 @@ static void lanner_handler_ok_reply(struct lanner_shared *l_shared)
 
     if (!l_shared->pending_ports_mask) {
         l_shared->mcu_state = LANNER_MCU_IDLE;
+        l_shared->pending_ports_mask = 0;
     }
 }
 

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -40,6 +40,8 @@ struct lanner_port {
 struct usb_monitor_ctx;
 struct json_object;
 
+void lanner_handler_start_mcu_update(struct usb_monitor_ctx *ctx);
+
 uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
                                   struct json_object *json,
                                   const char *mcu_path);

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -1,0 +1,23 @@
+#ifndef LANNER_HANDLER_H
+#define LANNER_HANDLER_H
+
+#include <stdint.h>
+
+enum {
+    LANNER_STATE_ON,
+    LANNER_STATE_OFF
+};
+
+struct lanner_port {
+    USB_PORT_MANDATORY;
+    uint8_t bit_num;
+    //Lanner does not allow control of a single port, instead we must write the complete bitmask every time
+    uint8_t cur_state;
+};
+
+struct usb_monitor_ctx;
+struct json_object;
+
+uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx, struct json_object *json);
+
+#endif

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -5,6 +5,8 @@
 
 #define LANNER_HANDLER_OK_REPLY "100 OK"
 
+#define LANNER_HANDLER_RESTART_MS   5000
+
 enum {
     LANNER_STATE_ON,
     LANNER_STATE_OFF
@@ -22,12 +24,14 @@ enum {
 };
 
 struct backend_epoll_handle;
+struct backend_timeout_handle;
 struct usb_monitor_ctx;
 
 struct lanner_shared {
     struct usb_monitor_ctx *ctx;
     char *mcu_path;
     struct backend_epoll_handle *mcu_epoll_handle;
+    struct backend_timeout_handle *mcu_timeout_handle;
 
     int mcu_fd;
     uint8_t mcu_state;

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -49,7 +49,6 @@ struct lanner_port {
     struct lanner_shared *shared_info;
     uint8_t bitmask;
     uint8_t cur_cmd;
-    uint8_t rest_sub_cmd;
     //Lanner does not allow control of a single port, instead we must write
     //the complete bitmask every time
     uint8_t cur_state;

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -49,6 +49,7 @@ struct lanner_port {
     struct lanner_shared *shared_info;
     uint8_t bitmask;
     uint8_t cur_cmd;
+    uint8_t rest_sub_cmd;
     //Lanner does not allow control of a single port, instead we must write
     //the complete bitmask every time
     uint8_t cur_state;

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -54,9 +54,6 @@ struct lanner_port {
     uint8_t bitmask;
     uint8_t cur_cmd;
     uint8_t restart_cmd;
-    //Lanner does not allow control of a single port, instead we must write
-    //the complete bitmask every time
-    uint8_t cur_state;
 };
 
 struct json_object;

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -8,15 +8,30 @@ enum {
     LANNER_STATE_OFF
 };
 
+enum {
+    //There are no pending operations for the MCU
+    LANNER_MCU_IDLE,
+    //There are pending operations, but we have not started updating yet
+    LANNER_MCU_PENDING,
+    //We are writing to the MCU, MCU locked
+    LANNER_MCU_WRITING,
+    //We are waiting for OK from the MCU, MCU locked
+    LANNER_MCU_WAIT_OK
+};
+
 struct lanner_shared {
     char *mcu_path;
     int mcu_fd;
+    uint8_t mcu_state;
+    //Mask of ports with a pending event
+    uint8_t mcu_ports_mask;
 };
 
 struct lanner_port {
     USB_PORT_MANDATORY;
     struct lanner_shared *shared_info;
     uint8_t bitmask;
+    uint8_t cur_cmd;
     //Lanner does not allow control of a single port, instead we must write
     //the complete bitmask every time
     uint8_t cur_state;

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -8,8 +8,14 @@ enum {
     LANNER_STATE_OFF
 };
 
+struct lanner_shared {
+    char *mcu_path;
+    int mcu_fd;
+};
+
 struct lanner_port {
     USB_PORT_MANDATORY;
+    struct lanner_shared *shared_info;
     uint8_t bitmask;
     //Lanner does not allow control of a single port, instead we must write the complete bitmask every time
     uint8_t cur_state;

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -24,7 +24,7 @@ struct lanner_shared {
     int mcu_fd;
     uint8_t mcu_state;
     //Mask of ports with a pending event
-    uint8_t mcu_ports_mask;
+    uint8_t pending_ports_mask;
 };
 
 struct lanner_port {

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -17,13 +17,16 @@ struct lanner_port {
     USB_PORT_MANDATORY;
     struct lanner_shared *shared_info;
     uint8_t bitmask;
-    //Lanner does not allow control of a single port, instead we must write the complete bitmask every time
+    //Lanner does not allow control of a single port, instead we must write
+    //the complete bitmask every time
     uint8_t cur_state;
 };
 
 struct usb_monitor_ctx;
 struct json_object;
 
-uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx, struct json_object *json);
+uint8_t lanner_handler_parse_json(struct usb_monitor_ctx *ctx,
+                                  struct json_object *json,
+                                  const char *mcu_path);
 
 #endif

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define LANNER_HANDLER_OK_REPLY "100 OK"
+
 enum {
     LANNER_STATE_ON,
     LANNER_STATE_OFF

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -10,7 +10,7 @@ enum {
 
 struct lanner_port {
     USB_PORT_MANDATORY;
-    uint8_t bit_num;
+    uint8_t bitmask;
     //Lanner does not allow control of a single port, instead we must write the complete bitmask every time
     uint8_t cur_state;
 };

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -19,12 +19,27 @@ enum {
     LANNER_MCU_WAIT_OK
 };
 
+struct backend_epoll_handle;
+struct usb_monitor_ctx;
+
 struct lanner_shared {
+    struct usb_monitor_ctx *ctx;
     char *mcu_path;
+    struct backend_epoll_handle *mcu_epoll_handle;
+
     int mcu_fd;
     uint8_t mcu_state;
     //Mask of ports with a pending event
     uint8_t pending_ports_mask;
+
+    //Buffer that will keep our output string. Big enough to contain:
+    //SET DIGITAL_OUT X\n\0, where X has three digits
+    char cmd_buf[21];
+    char buf_input[256];
+
+    uint8_t cmd_buf_strlen;
+    uint8_t cmd_buf_progress;
+    uint8_t input_progress;
 };
 
 struct lanner_port {
@@ -37,7 +52,6 @@ struct lanner_port {
     uint8_t cur_state;
 };
 
-struct usb_monitor_ctx;
 struct json_object;
 
 void lanner_handler_start_mcu_update(struct usb_monitor_ctx *ctx);

--- a/src/lanner_handler.h
+++ b/src/lanner_handler.h
@@ -49,6 +49,7 @@ struct lanner_port {
     struct lanner_shared *shared_info;
     uint8_t bitmask;
     uint8_t cur_cmd;
+    uint8_t restart_cmd;
     //Lanner does not allow control of a single port, instead we must write
     //the complete bitmask every time
     uint8_t cur_state;

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -444,11 +444,13 @@ void usb_helpers_reset_all_ports(struct usb_monitor_ctx *ctx, uint8_t forced)
     LIST_FOREACH(itr, &(ctx->port_list), port_next) {
         //Only restart enabled ports which are not connected and are currently
         //not being reset or probed
-        if (itr->msg_mode == RESET || !itr->enabled || itr->msg_mode == PROBE)
+        if (itr->msg_mode == RESET || !itr->enabled || itr->msg_mode == PROBE) {
             continue;
+        }
 
-        if (forced || itr->status == PORT_NO_DEV_CONNECTED)
+        if (forced || itr->status == PORT_NO_DEV_CONNECTED) {
             itr->update(itr, CMD_RESTART);
+        }
     }
 }
 

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -279,15 +279,17 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
         if (port->num_retrans == USB_RETRANS_LIMIT) {
             port->num_retrans = 0;
             if (port->msg_mode != RESET) {
+                //If restart fails, we want to try again right away. Do that
+                //after timer expires next time.
                 if (port->update(port, CMD_RESTART)) {
                     port->num_retrans = USB_RETRANS_LIMIT;
-                    usb_helpers_start_timeout(port, DEFAULT_TIMEOUT_SEC);
+                } else {
+                    return;
                 }
             }
-            return;
+        } else {
+            port->num_retrans++;
         }
-
-        port->num_retrans++;
     /*} else {
         if (++port->ping_cnt == PING_OUTPUT) {
             USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO,

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -267,10 +267,11 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
     //With asynchrnous enable/disale/reset requests, we might be waiting for a
     //"ping" reply when request occurs. If this happens and reply arrives before
     //device is removed, ignore ping reply
-    if (!port->enabled || port->msg_mode != PING)
+    if (!port->enabled || port->msg_mode != PING) {
         return;
+    }
 
-    if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
+    //if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
         USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_ERR,
                 "Ping failed for %.4x:%.4x\n",
                 port->vp.vid, port->vp.pid);
@@ -278,11 +279,12 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
 
         if (port->num_retrans == USB_RETRANS_LIMIT) {
             port->num_retrans = 0;
-            if (port->msg_mode != RESET)
+            if (port->msg_mode != RESET) {
                 port->update(port, CMD_RESTART);
+            }
             return;
         }
-    } else {
+    /*} else {
         if (++port->ping_cnt == PING_OUTPUT) {
             USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO,
                     "Ping success for %.4x:%.4x\n",
@@ -290,7 +292,7 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
             port->ping_cnt = 0;
         }
         port->num_retrans = 0;
-    }
+    }*/
 
     //We can only get into this function after timeout has been handeled and
     //removed from timeout list. It is therefore safe to add the port to the

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -279,7 +279,9 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
         if (port->num_retrans == USB_RETRANS_LIMIT) {
             port->num_retrans = 0;
             if (port->msg_mode != RESET) {
-                port->update(port, CMD_RESTART);
+                if (port->update(port, CMD_RESTART)) {
+                    usb_helpers_start_timeout(port, DEFAULT_TIMEOUT_SEC);
+                }
             }
             return;
         }

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -271,7 +271,7 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
         return;
     }
 
-    //if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
+    if (transfer->status != LIBUSB_TRANSFER_COMPLETED) {
         USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_ERR,
                 "Ping failed for %.4x:%.4x\n",
                 port->vp.vid, port->vp.pid);
@@ -290,7 +290,7 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
         } else {
             port->num_retrans++;
         }
-    /*} else {
+    } else {
         if (++port->ping_cnt == PING_OUTPUT) {
             USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO,
                     "Ping success for %.4x:%.4x\n",
@@ -298,7 +298,7 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
             port->ping_cnt = 0;
         }
         port->num_retrans = 0;
-    }*/
+    }
 
     //We can only get into this function after timeout has been handeled and
     //removed from timeout list. It is therefore safe to add the port to the

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -280,6 +280,7 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
             port->num_retrans = 0;
             if (port->msg_mode != RESET) {
                 if (port->update(port, CMD_RESTART)) {
+                    port->num_retrans = USB_RETRANS_LIMIT;
                     usb_helpers_start_timeout(port, DEFAULT_TIMEOUT_SEC);
                 }
             }

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -277,7 +277,7 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
                 port->vp.vid, port->vp.pid);
         port->num_retrans++;
 
-        if (port->num_retrans == USB_RETRANS_LIMIT) {
+        if (port->num_retrans >= USB_RETRANS_LIMIT) {
             port->num_retrans = 0;
             if (port->msg_mode != RESET) {
                 port->update(port, CMD_RESTART);

--- a/src/usb_helpers.c
+++ b/src/usb_helpers.c
@@ -275,15 +275,16 @@ static void usb_helpers_ping_cb(struct libusb_transfer *transfer)
         USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_ERR,
                 "Ping failed for %.4x:%.4x\n",
                 port->vp.vid, port->vp.pid);
-        port->num_retrans++;
 
-        if (port->num_retrans >= USB_RETRANS_LIMIT) {
+        if (port->num_retrans == USB_RETRANS_LIMIT) {
             port->num_retrans = 0;
             if (port->msg_mode != RESET) {
                 port->update(port, CMD_RESTART);
             }
             return;
         }
+
+        port->num_retrans++;
     /*} else {
         if (++port->ping_cnt == PING_OUTPUT) {
             USB_DEBUG_PRINT_SYSLOG(port->ctx, LOG_INFO,

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -61,7 +61,13 @@ void usb_monitor_print_ports(struct usb_monitor_ctx *ctx)
 
 void usb_monitor_start_itr_cb(struct usb_monitor_ctx *ctx)
 {
+    ctx->event_loop->itr_data = ctx;
     ctx->event_loop->itr_cb = usb_monitor_itr_cb;
+}
+
+void usb_monitor_stop_itr_cb(struct usb_monitor_ctx *ctx)
+{
+    ctx->event_loop->itr_cb = ctx->event_loop->itr_data = NULL;
 }
 
 static uint8_t usb_monitor_parse_handlers(struct usb_monitor_ctx *ctx,
@@ -381,7 +387,6 @@ static uint8_t usb_monitor_configure(struct usb_monitor_ctx *ctx, uint8_t sock)
     //We handle maximum of five concurrent clients
     ctx->clients_map = 0x1F;
     ctx->event_loop = backend_event_loop_create();
-    ctx->event_loop->itr_data = ctx;
 
     for (i = 0; i < MAX_HTTP_CLIENTS; i++)
         ctx->clients[i] = NULL;

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -44,6 +44,7 @@
 #include "usb_monitor_callbacks.h"
 #include "socket_utility.h"
 #include "usb_monitor_client.h"
+#include "lanner_handler.h"
 
 //Kept global so that I can access it from the signal handler
 static struct usb_monitor_ctx *usbmon_ctx = NULL;
@@ -94,8 +95,13 @@ static uint8_t usb_monitor_parse_handlers(struct usb_monitor_ctx *ctx,
         }
 
         if (!strcmp("GPIO", handler_name)) {
-            if (gpio_handler_parse_json(ctx, handler_obj))
+            if (gpio_handler_parse_json(ctx, handler_obj)) {
                 return 1;
+            }
+        } else if (!strcmp("Lanner", handler_name)) {
+            if (lanner_handler_parse_json(ctx, handler_obj)) {
+                return 1;
+            }
         } else {
             fprintf(stderr, "Unknown handler in JSON\n");
             return 1;

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -59,6 +59,10 @@ void usb_monitor_print_ports(struct usb_monitor_ctx *ctx)
     fprintf(ctx->logfile, "\n");
 }
 
+void usb_monitor_start_itr_cb(struct usb_monitor_ctx *ctx)
+{
+    ctx->event_loop->itr_cb = usb_monitor_itr_cb;
+}
 
 static uint8_t usb_monitor_parse_handlers(struct usb_monitor_ctx *ctx,
                                           struct json_object *handlers)
@@ -263,21 +267,24 @@ static void usb_monitor_start_event_loop(struct usb_monitor_ctx *ctx)
     //These timeout pointers will live for as long as the application.
     //Therefore, there is no need to save them anywhere
     if (!backend_event_loop_add_timeout(ctx->event_loop, cur_time + 1000,
-                                        usb_monitor_1sec_timeout_cb, ctx, 1000))
+                                        usb_monitor_1sec_timeout_cb, ctx, 1000)) {
         return;
+    }
    
     //Do not make this one a multiple of reset_cb timeout. There is no need
     //resetting and checking at the same time
     if (!backend_event_loop_add_timeout(ctx->event_loop, cur_time + 25000,
                                         usb_monitor_check_devices_cb,
-                                        ctx, 25000))
+                                        ctx, 25000)) {
         return;
+    }
 
     if (!ctx->disable_auto_restart &&
         !backend_event_loop_add_timeout(ctx->event_loop, cur_time + 60000,
                                         usb_monitor_check_reset_cb,
-                                        ctx, 60000))
+                                        ctx, 60000)) {
         return;
+    }
 
     backend_event_loop_run(ctx->event_loop);
 }

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -380,7 +380,8 @@ static uint8_t usb_monitor_configure(struct usb_monitor_ctx *ctx, uint8_t sock)
 
     //We handle maximum of five concurrent clients
     ctx->clients_map = 0x1F;
-    ctx->event_loop = backend_event_loop_create(); 
+    ctx->event_loop = backend_event_loop_create();
+    ctx->event_loop->itr_data = ctx;
 
     for (i = 0; i < MAX_HTTP_CLIENTS; i++)
         ctx->clients[i] = NULL;

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -287,9 +287,9 @@ static void usb_monitor_start_event_loop(struct usb_monitor_ctx *ctx)
     }
 
     if (!ctx->disable_auto_restart &&
-        !backend_event_loop_add_timeout(ctx->event_loop, cur_time + 60000,
+        !backend_event_loop_add_timeout(ctx->event_loop, cur_time + 120000,
                                         usb_monitor_check_reset_cb,
-                                        ctx, 60000, true)) {
+                                        ctx, 120000, true)) {
         return;
     }
 

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -65,7 +65,7 @@ static uint8_t usb_monitor_parse_handlers(struct usb_monitor_ctx *ctx,
 {
     int handlers_len = 0, i;
     uint8_t unknown_elem = 0;
-    const char *handler_name = NULL;
+    const char *handler_name = NULL, *mcu_path = NULL;
     struct json_object *arr_obj, *handler_obj = NULL;
     
     handlers_len = json_object_array_length(handlers);
@@ -83,6 +83,10 @@ static uint8_t usb_monitor_parse_handlers(struct usb_monitor_ctx *ctx,
             } else if(!strcmp(key, "ports")) {
                 handler_obj = val;
                 continue;
+            } else if (!strcmp(key, "mcu_path")) {
+                //This value is only used by lanner and don't really belong in
+                //the main, generic object. Think of a better structure
+                mcu_path = json_object_get_string(val);
             } else {
                 unknown_elem = 1;
                 break;
@@ -99,7 +103,7 @@ static uint8_t usb_monitor_parse_handlers(struct usb_monitor_ctx *ctx,
                 return 1;
             }
         } else if (!strcmp("Lanner", handler_name)) {
-            if (lanner_handler_parse_json(ctx, handler_obj)) {
+            if (lanner_handler_parse_json(ctx, handler_obj, mcu_path)) {
                 return 1;
             }
         } else {

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -273,7 +273,8 @@ static void usb_monitor_start_event_loop(struct usb_monitor_ctx *ctx)
     //These timeout pointers will live for as long as the application.
     //Therefore, there is no need to save them anywhere
     if (!backend_event_loop_add_timeout(ctx->event_loop, cur_time + 1000,
-                                        usb_monitor_1sec_timeout_cb, ctx, 1000)) {
+                                        usb_monitor_1sec_timeout_cb, ctx, 1000,
+                                        true)) {
         return;
     }
    
@@ -281,14 +282,14 @@ static void usb_monitor_start_event_loop(struct usb_monitor_ctx *ctx)
     //resetting and checking at the same time
     if (!backend_event_loop_add_timeout(ctx->event_loop, cur_time + 25000,
                                         usb_monitor_check_devices_cb,
-                                        ctx, 25000)) {
+                                        ctx, 25000, true)) {
         return;
     }
 
     if (!ctx->disable_auto_restart &&
         !backend_event_loop_add_timeout(ctx->event_loop, cur_time + 60000,
                                         usb_monitor_check_reset_cb,
-                                        ctx, 60000)) {
+                                        ctx, 60000, true)) {
         return;
     }
 

--- a/src/usb_monitor.c
+++ b/src/usb_monitor.c
@@ -263,7 +263,7 @@ static void usb_monitor_start_event_loop(struct usb_monitor_ctx *ctx)
     //These timeout pointers will live for as long as the application.
     //Therefore, there is no need to save them anywhere
     if (!backend_event_loop_add_timeout(ctx->event_loop, cur_time + 1000,
-                                        usb_monitor_itr_cb, ctx, 1000))
+                                        usb_monitor_1sec_timeout_cb, ctx, 1000))
         return;
    
     //Do not make this one a multiple of reset_cb timeout. There is no need

--- a/src/usb_monitor.h
+++ b/src/usb_monitor.h
@@ -41,6 +41,8 @@ struct backend_epoll_handle;
 struct backend_event_loop;
 struct http_client;
 
+struct lanner_shared;
+
 //port function pointers
 typedef void (*print_port)(struct usb_port *port);
 typedef int32_t (*update_port)(struct usb_port *port, uint8_t cmd);
@@ -136,6 +138,7 @@ struct usb_monitor_ctx {
     struct backend_epoll_handle *accept_handle;
     struct usb_bad_device *bad_device_ids;
     struct http_client *clients[MAX_HTTP_CLIENTS];
+    struct lanner_shared *mcu_state;
     struct timeval last_restart;
     struct timeval last_dev_check;
     FILE* logfile;
@@ -151,5 +154,7 @@ struct usb_monitor_ctx {
 
 //Output all of the ports, move to helpers?
 void usb_monitor_print_ports(struct usb_monitor_ctx *ctx);
+
+void usb_monitor_start_itr_cb();
 
 #endif

--- a/src/usb_monitor.h
+++ b/src/usb_monitor.h
@@ -49,7 +49,8 @@ typedef void (*handle_timeout)(struct usb_port *port);
 enum {
     PORT_TYPE_UNKNOWN = 0,
     PORT_TYPE_GPIO,
-    PORT_TYPE_YKUSH
+    PORT_TYPE_YKUSH,
+    PORT_TYPE_LANNER
 };
 
 //The device pointed to here is the device that will be used for comparison when

--- a/src/usb_monitor.h
+++ b/src/usb_monitor.h
@@ -155,6 +155,7 @@ struct usb_monitor_ctx {
 //Output all of the ports, move to helpers?
 void usb_monitor_print_ports(struct usb_monitor_ctx *ctx);
 
-void usb_monitor_start_itr_cb();
+void usb_monitor_start_itr_cb(struct usb_monitor_ctx *ctx);
+void usb_monitor_stop_itr_cb(struct usb_monitor_ctx *ctx);
 
 #endif

--- a/src/usb_monitor.h
+++ b/src/usb_monitor.h
@@ -138,7 +138,7 @@ struct usb_monitor_ctx {
     struct backend_epoll_handle *accept_handle;
     struct usb_bad_device *bad_device_ids;
     struct http_client *clients[MAX_HTTP_CLIENTS];
-    struct lanner_shared *mcu_state;
+    struct lanner_shared *mcu_info;
     struct timeval last_restart;
     struct timeval last_dev_check;
     FILE* logfile;

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -231,3 +231,9 @@ void usb_monitor_libusb_fd_remove(int fd, void *data)
     close(fd);
 }
 
+void usb_monitor_itr_cb(void *ptr)
+{
+    struct usb_monitor_ctx *ctx = ptr;
+
+    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_DEBUG, "Heihei from itr\n");
+}

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -98,9 +98,9 @@ static void usb_device_added(struct usb_monitor_ctx *ctx, libusb_device *dev)
         port->msg_mode = PING;
         usb_helpers_start_timeout(port, ADDED_TIMEOUT_SEC);
 
-	if (usb_helpers_check_bad_id(ctx, port)) {
-		port->update(port, CMD_RESTART);
-	}
+	    if (usb_helpers_check_bad_id(ctx, port)) {
+		    port->update(port, CMD_RESTART);
+	    }
     }
 }
 

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -29,6 +29,7 @@
 #include "backend_event_loop.h"
 
 #include "gpio_handler.h"
+#include "lanner_handler.h"
 
 /* libusb-callbacks for when devices are added/removed. It is also called
  * manually when we detect a hub, since we risk devices being added before we
@@ -235,7 +236,6 @@ void usb_monitor_itr_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
 
-    USB_DEBUG_PRINT_SYSLOG(ctx, LOG_DEBUG, "Heihei from itr\n");
-
+    lanner_handler_start_mcu_update(ctx);
     usb_monitor_stop_itr_cb(ctx);
 }

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -236,4 +236,6 @@ void usb_monitor_itr_cb(void *ptr)
     struct usb_monitor_ctx *ctx = ptr;
 
     USB_DEBUG_PRINT_SYSLOG(ctx, LOG_DEBUG, "Heihei from itr\n");
+
+    usb_monitor_stop_itr_cb(ctx);
 }

--- a/src/usb_monitor_callbacks.c
+++ b/src/usb_monitor_callbacks.c
@@ -197,16 +197,14 @@ void usb_monitor_check_reset_cb(void *ptr)
     usb_helpers_reset_all_ports(ctx, 0);
 }
 
-//This function is called for every iteration + every second. Latter is needed
-//in case of restart
-void usb_monitor_itr_cb(void *ptr)
+//This function is called every second.
+void usb_monitor_1sec_timeout_cb(void *ptr)
 {
     struct usb_monitor_ctx *ctx = ptr;
     struct timeval tv = {0 ,0};
 
     //First, check for any of libusb's timers. We are incontrol of timer, so no
     //need for this function to block
-
     libusb_unlock_events(NULL);
     libusb_handle_events_timeout_completed(NULL, &tv, NULL);
     libusb_lock_events(NULL);

--- a/src/usb_monitor_callbacks.h
+++ b/src/usb_monitor_callbacks.h
@@ -36,4 +36,8 @@ void usb_monitor_1sec_timeout_cb(void *ptr);
 void usb_monitor_libusb_fd_add(int fd, short events, void *data);
 void usb_monitor_libusb_fd_remove(int fd, void *data);
 
+//This is a callback is used to check + start updating the power of different
+//modems on Lanner devices
+void usb_monitor_itr_cb(void *ptr);
+
 #endif

--- a/src/usb_monitor_callbacks.h
+++ b/src/usb_monitor_callbacks.h
@@ -30,7 +30,7 @@ void usb_monitor_usb_event_cb(void *ptr, int32_t fd, uint32_t events);
 //These are the three timeout callbacks
 void usb_monitor_check_devices_cb(void *ptr);
 void usb_monitor_check_reset_cb(void *ptr);
-void usb_monitor_itr_cb(void *ptr);
+void usb_monitor_1sec_timeout_cb(void *ptr);
 
 //Libusb file descriptor callbacks
 void usb_monitor_libusb_fd_add(int fd, short events, void *data);


### PR DESCRIPTION
Many Lanner devices support power-cycling the internal USB-ports by writing a bitmask to an MCU (via a well-defined serial device). The bitmask contains the state for each port (as well as which SIM slot the ports shall use), so individual per-port power cycling is not possible. All ports are updated when we write. This is different than the other power cycling-techniques we support in usb-monitor.

In order to add support for power-cycling ports on Lanner-devices we have added a new port type, `PORT_TYPE_LANNER`. In addition to the mandatory fields, we store the bit which controls the port (power is controlled by setting/not setting a given bit), the current command (`ENABLE`, `DISABLE` or `RESTART`) as well as restart_cmd. The reason we need a separate restart_cmd will be explained later.

A Lanner-port is handled in more or less the same way as any other port, except when we update state. Since the MCU is an exclusive resource, we can only have one update in progress at the time. The MCU is represented by a struct we have named `lanner_shared`. When a port is updated, we set the corresponding bit in the variable pending_ports_mask in `lanner_shared`. We also start an iterator callback, i.e., a function that is called once the current iteration of the event loop is over.

The iterator callback, called `usb_monitor_itr_cb()`, calls the function `lanner_handler_start_mcu_update()` and then removes the callback. `lanner_handler_start_mcu_update()` iterates through all ports of `PORT_TYPE_LANNER`, and creates the bitmask that will be written to the MCU. If the bit representing a port is set in the mask passed to the MCU, then the port will be disabled. We start off by assuming that all ports will be enabled, and then set the bits for all ports that are disabled or that should be disabled (cmd equals `CMD_DISABLE`). 

Since the MCU will update the power-state of all ports, we need to potentially set the bit for all ports and not only those that are updated. We also set the state of the MCU (`lanner_shared->mcu_state`) to `LANNER_MCU_WRITING` in `lanner_handler_start_mcu_update()`. This state (together with one more) is used to block updating the power of Lanner ports until the current update is done. Once all of this is done, we start writing the bitmask to the MCU.

We support partial writes, and when we are doing writing we change state to `LANNCER_MCU_WAIT_OK` (also used for blocking additional updates). The MCU replies with 100 OK when the update is done. If we received something else, we try again after a short timer has expired. We have sometimes seen that the device complains about a full buffer, but the error always disappears by itself.

When 100 OK is received, we call `lanner_handler_ok_reply()`. This function iterates through the ports of `PORT_TYPE_LANNER` where bit is set in `lanner_shared->pending_ports_mask`. We update the state of the port based on the given command. If command was either `ENABLE` or `DISABLE` (so not `RESTART`), we also unset the bit in pending_ports_mask. If pending_ports_mask is 0 after we are done iterating, then we are done with the MCU and set the state to `MCU_IDLE`. This indicates that the MCU is unlocked and new updates can be made.

`pending_ports_mask` is only non-zero when one or more ports are to be restarted. Restart needs to be handled differently than enabling or disabling, since restart requires two operations. When a user requests a port to be restarted, we set `lanner_port->cmd` to `RESTART` and `restart_cmd` to `DISABLE`. When port is disabled, instead of unsetting the bit from pending_ports_mask, we change command to `CMD_ENABLE` in `lanner_handler_ok_reply()`. When the `pending_ports_mask` is not zero, we change state back to `WRITING` after we are done iterating and start a timer. The callback triggered by this timer will call `lanner_handler_start_mcu_update()`, which will enable the port(s) again. When we are back in `lanner_handler_ok_reply()`, we unset the bits from pending_ports_mask (we always do that for `ENABLE`) and unlock the device.

Tested:
* Basic functionality (enable, disable, restart) works. Tested by triggering the functioality via the REST API, as well as signal handler (for restart).
* Partial read/partial write works fine. Tested by reading/writing one button at a time.
* Exclusive access works. Tested by changing idle state to one of the blocking states. Also tested by requesting two updates very close together.
* Basic error handling (unexpected return value from MCU, file descriptor returning EAGAIN on write) works. Tested by instrumenting the code to trigger the errors.